### PR TITLE
fix(build): add repository field for npm provenance

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "@cognigy/plugin-engine",
   "version": "1.0.0",
-  "description": "MCP server engine for the Cognigy Platform plugin (Claude Code, Codex, and more)",
+  "description": "MCP server engine for the NiCE Cognigy Plugin (Claude Code, Codex, and more)",
   "main": "dist/index.js",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Cognigy/cognigy-plugin"
+  },
   "files": [
     "dist",
     "README.md"


### PR DESCRIPTION
The release on `main` failed at publish:

```
npm error 422 ... Error verifying sigstore provenance bundle:
package.json: "repository.url" is "", expected to match "https://github.com/Cognigy/cognigy-plugin"
```

semantic-release publishes `@cognigy/plugin-engine` with `--provenance`, which requires `package.json.repository.url` to match the GitHub repo. The field was missing. This adds it (and aligns the package description to "NiCE Cognigy Plugin").

semantic-release aborted cleanly on the failure — no tag, no commit, npm still at `1.0.0` — so once this merges, the Release workflow re-runs and cuts `1.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)