### PR TITLE
feat(setup): cognigy-setup CLI for GUI credential config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,16 @@ The plugin is supported by **Claude Code** and **Codex** today; more clients wil
 
 On enable, Claude Code prompts for your **Cognigy API base URL** (default `https://api-trial.cognigy.ai`) and **API key** (Cognigy.AI → User Menu → My Profile → API Keys). The key is stored in your system keychain. Requires [Node.js 20+](https://nodejs.org).
 
+#### If you install from the GUI and aren't prompted for credentials
+
+The desktop/web app installs the plugin cleanly but does not always show the credential prompt. If the Cognigy tools report a missing API key, run the setup command once in any terminal:
+
+```
+npx @cognigy/plugin-engine cognigy-setup
+```
+
+It asks for your API base URL (press Enter for the trial default) and API key (masked — never echoed), then writes them to `~/.cognigy-plugin/config.json` with owner-only permissions (`chmod 600`). Restart Claude Code afterwards. The engine reads this file only when the environment variables are absent, so the terminal/keychain flow above is unaffected. For scripted setup, pass `--api-base-url` and `--api-key` instead of answering prompts.
+
 The first session downloads the server into the plugin's data directory, which takes a moment. If the Cognigy tools don't appear right away on that first launch, run `/mcp`, reconnect the Cognigy server (or restart Claude Code) — later sessions connect instantly, and the engine updates in lockstep when you update the plugin.
 
 Beyond the MCP tools, the plugin ships **skills** and **agents** that surface the workflows automatically:
@@ -72,7 +82,7 @@ Create a complete AI Agent in one tool call, then iterate and improve through co
 
 ## Configuration
 
-The plugin collects your **Cognigy API base URL** and **API key** through Claude Code's install prompt (stored in the system keychain) and passes them to the server as environment variables. The optional variables below can be set in the plugin's MCP server `env` if you need to override defaults.
+The plugin collects your **Cognigy API base URL** and **API key** through Claude Code's install prompt (stored in the system keychain) and passes them to the server as environment variables. When the installer does not prompt (see the GUI note under [Installation](#claude-code)), `npx @cognigy/plugin-engine cognigy-setup` writes the same two values to `~/.cognigy-plugin/config.json` (`chmod 600`); the engine reads that file only when the matching environment variable is unset. The optional variables below can be set in the plugin's MCP server `env` if you need to override defaults.
 
 | Variable                  | Required | Default | Description                      |
 | ------------------------- | -------- | ------- | -------------------------------- |

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "MCP server engine for the NiCE Cognigy Plugin (Claude Code, Codex, and more)",
   "main": "dist/index.js",
   "type": "module",
+  "bin": {
+    "cognigy-setup": "dist/setup.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/Cognigy/cognigy-plugin"

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,131 +1,155 @@
-import { describe, it, expect, beforeEach, afterEach } from '@jest/globals';
-import { loadConfig } from '../config.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
 
-describe('loadConfig', () => {
+// Mock the on-disk fallback so tests never touch the real ~/.cognigy-plugin.
+// Default: empty (behaves as if no fallback file exists).
+const readUserConfigFile = jest.fn<() => Record<string, string>>(() => ({}));
+jest.unstable_mockModule("../userConfigFile.js", () => ({
+  readUserConfigFile,
+  writeUserConfigFile: jest.fn(),
+  USER_CONFIG_FILE: "/fake/.cognigy-plugin/config.json",
+  USER_CONFIG_DIR: "/fake/.cognigy-plugin",
+}));
+
+const { loadConfig } = await import("../config.js");
+
+describe("loadConfig", () => {
   let savedEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
     savedEnv = { ...process.env };
+    readUserConfigFile.mockReset();
+    readUserConfigFile.mockReturnValue({});
   });
 
   afterEach(() => {
     process.env = savedEnv;
   });
 
-  it('throws when COGNIGY_API_BASE_URL is missing', () => {
+  it("throws when COGNIGY_API_BASE_URL is missing", () => {
     delete process.env.COGNIGY_API_BASE_URL;
-    process.env.COGNIGY_API_KEY = 'test-key';
-    expect(() => loadConfig()).toThrow('COGNIGY_API_BASE_URL environment variable is required');
+    process.env.COGNIGY_API_KEY = "test-key";
+    expect(() => loadConfig()).toThrow(/COGNIGY_API_BASE_URL is not set/);
   });
 
-  it('throws when COGNIGY_API_KEY is missing', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
+  it("throws when COGNIGY_API_KEY is missing", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
     delete process.env.COGNIGY_API_KEY;
-    expect(() => loadConfig()).toThrow('COGNIGY_API_KEY environment variable is required');
+    expect(() => loadConfig()).toThrow(/COGNIGY_API_KEY is not set/);
   });
 
-  it('normalizes bare UI URL to API URL', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://dev.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("normalizes bare UI URL to API URL", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://dev.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     const config = loadConfig();
-    expect(config.apiBaseUrl).toBe('https://api-dev.cognigy.ai');
+    expect(config.apiBaseUrl).toBe("https://api-dev.cognigy.ai");
   });
 
-  it('keeps already-correct API URL unchanged', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("keeps already-correct API URL unchanged", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     const config = loadConfig();
-    expect(config.apiBaseUrl).toBe('https://api-trial.cognigy.ai');
+    expect(config.apiBaseUrl).toBe("https://api-trial.cognigy.ai");
   });
 
-  it('strips trailing slashes from API URL', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai///';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("strips trailing slashes from API URL", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai///";
+    process.env.COGNIGY_API_KEY = "test-key";
     const config = loadConfig();
-    expect(config.apiBaseUrl).toBe('https://api-trial.cognigy.ai');
+    expect(config.apiBaseUrl).toBe("https://api-trial.cognigy.ai");
   });
 
-  it('derives endpoint URL from API URL', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("derives endpoint URL from API URL", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     const config = loadConfig();
-    expect(config.endpointBaseUrl).toBe('https://endpoint-trial.cognigy.ai');
+    expect(config.endpointBaseUrl).toBe("https://endpoint-trial.cognigy.ai");
   });
 
-  it('derives webchat URL from API URL', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("derives webchat URL from API URL", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     const config = loadConfig();
-    expect(config.webchatBaseUrl).toBe('https://webchat-trial.cognigy.ai');
+    expect(config.webchatBaseUrl).toBe("https://webchat-trial.cognigy.ai");
   });
 
-  it('uses explicit COGNIGY_ENDPOINT_BASE_URL if provided', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.COGNIGY_ENDPOINT_BASE_URL = 'https://custom-endpoint.example.com';
+  it("uses explicit COGNIGY_ENDPOINT_BASE_URL if provided", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.COGNIGY_ENDPOINT_BASE_URL =
+      "https://custom-endpoint.example.com";
     const config = loadConfig();
-    expect(config.endpointBaseUrl).toBe('https://custom-endpoint.example.com');
+    expect(config.endpointBaseUrl).toBe("https://custom-endpoint.example.com");
   });
 
-  it('uses explicit COGNIGY_WEBCHAT_BASE_URL if provided', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.COGNIGY_WEBCHAT_BASE_URL = 'https://custom-webchat.example.com';
+  it("uses explicit COGNIGY_WEBCHAT_BASE_URL if provided", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.COGNIGY_WEBCHAT_BASE_URL = "https://custom-webchat.example.com";
     const config = loadConfig();
-    expect(config.webchatBaseUrl).toBe('https://custom-webchat.example.com');
+    expect(config.webchatBaseUrl).toBe("https://custom-webchat.example.com");
   });
 
-  it('defaults serverName to cognigy-api-mcp', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("defaults serverName to cognigy-api-mcp", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     delete process.env.MCP_SERVER_NAME;
     const config = loadConfig();
-    expect(config.serverName).toBe('cognigy-api-mcp');
+    expect(config.serverName).toBe("cognigy-api-mcp");
   });
 
-  it('uses custom MCP_SERVER_NAME if provided', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.MCP_SERVER_NAME = 'my-custom-server';
+  it("uses custom MCP_SERVER_NAME if provided", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.MCP_SERVER_NAME = "my-custom-server";
     const config = loadConfig();
-    expect(config.serverName).toBe('my-custom-server');
+    expect(config.serverName).toBe("my-custom-server");
   });
 
-  it('defaults logLevel to info', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("defaults logLevel to info", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     delete process.env.LOG_LEVEL;
     const config = loadConfig();
-    expect(config.logLevel).toBe('info');
+    expect(config.logLevel).toBe("info");
   });
 
-  it.each(['debug', 'warn', 'error'] as const)('accepts valid log level: %s', (level) => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.LOG_LEVEL = level;
+  it.each(["debug", "warn", "error"] as const)(
+    "accepts valid log level: %s",
+    (level) => {
+      process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+      process.env.COGNIGY_API_KEY = "test-key";
+      process.env.LOG_LEVEL = level;
+      const config = loadConfig();
+      expect(config.logLevel).toBe(level);
+    },
+  );
+
+  it("falls back to info for invalid LOG_LEVEL", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.LOG_LEVEL = "verbose";
     const config = loadConfig();
-    expect(config.logLevel).toBe(level);
+    expect(config.logLevel).toBe("info");
   });
 
-  it('falls back to info for invalid LOG_LEVEL', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.LOG_LEVEL = 'verbose';
-    const config = loadConfig();
-    expect(config.logLevel).toBe('info');
-  });
-
-  it('parses RATE_LIMIT_MAX_REQUESTS correctly', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.RATE_LIMIT_MAX_REQUESTS = '50';
+  it("parses RATE_LIMIT_MAX_REQUESTS correctly", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.RATE_LIMIT_MAX_REQUESTS = "50";
     const config = loadConfig();
     expect(config.rateLimit.maxRequests).toBe(50);
   });
 
-  it('defaults rate limit values when env vars not set', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
+  it("defaults rate limit values when env vars not set", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
     delete process.env.RATE_LIMIT_MAX_REQUESTS;
     delete process.env.RATE_LIMIT_WINDOW_MS;
     const config = loadConfig();
@@ -133,13 +157,52 @@ describe('loadConfig', () => {
     expect(config.rateLimit.windowMs).toBe(60000);
   });
 
-  it('falls back to defaults for non-numeric rate limit values', () => {
-    process.env.COGNIGY_API_BASE_URL = 'https://api-trial.cognigy.ai';
-    process.env.COGNIGY_API_KEY = 'test-key';
-    process.env.RATE_LIMIT_MAX_REQUESTS = 'not-a-number';
-    process.env.RATE_LIMIT_WINDOW_MS = 'abc';
+  it("falls back to defaults for non-numeric rate limit values", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+    process.env.COGNIGY_API_KEY = "test-key";
+    process.env.RATE_LIMIT_MAX_REQUESTS = "not-a-number";
+    process.env.RATE_LIMIT_WINDOW_MS = "abc";
     const config = loadConfig();
     expect(config.rateLimit.maxRequests).toBe(100);
     expect(config.rateLimit.windowMs).toBe(60000);
+  });
+
+  describe("on-disk fallback (setup CLI)", () => {
+    it("does not read the fallback file when both env vars are set", () => {
+      process.env.COGNIGY_API_BASE_URL = "https://api-dev.cognigy.ai";
+      process.env.COGNIGY_API_KEY = "env-key";
+      loadConfig();
+      expect(readUserConfigFile).not.toHaveBeenCalled();
+    });
+
+    it("sources both values from the file when env vars are absent", () => {
+      delete process.env.COGNIGY_API_BASE_URL;
+      delete process.env.COGNIGY_API_KEY;
+      readUserConfigFile.mockReturnValue({
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+        COGNIGY_API_KEY: "file-key",
+      });
+      const config = loadConfig();
+      expect(config.apiBaseUrl).toBe("https://api-trial.cognigy.ai");
+      expect(config.apiKey).toBe("file-key");
+    });
+
+    it("lets an env var take precedence over the file per-field", () => {
+      delete process.env.COGNIGY_API_BASE_URL;
+      process.env.COGNIGY_API_KEY = "env-key";
+      readUserConfigFile.mockReturnValue({
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+        COGNIGY_API_KEY: "file-key",
+      });
+      const config = loadConfig();
+      expect(config.apiBaseUrl).toBe("https://api-trial.cognigy.ai"); // from file
+      expect(config.apiKey).toBe("env-key"); // env wins
+    });
+
+    it("points users at the setup command when nothing is configured", () => {
+      delete process.env.COGNIGY_API_BASE_URL;
+      delete process.env.COGNIGY_API_KEY;
+      expect(() => loadConfig()).toThrow(/setup/);
+    });
   });
 });

--- a/src/__tests__/userConfigFile.test.ts
+++ b/src/__tests__/userConfigFile.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, afterEach } from "@jest/globals";
+import { mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { readUserConfigFile, writeUserConfigFile } from "../userConfigFile.js";
+
+const tmpDirs: string[] = [];
+function freshDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "cognigy-cfg-"));
+  tmpDirs.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tmpDirs.length) {
+    rmSync(tmpDirs.pop() as string, { recursive: true, force: true });
+  }
+});
+
+describe("writeUserConfigFile", () => {
+  it("writes the values as JSON and returns the file path", () => {
+    const dir = freshDir();
+    const file = writeUserConfigFile(
+      {
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+        COGNIGY_API_KEY: "k",
+      },
+      dir,
+    );
+    expect(file).toBe(join(dir, "config.json"));
+    expect(readUserConfigFile(file)).toEqual({
+      COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+      COGNIGY_API_KEY: "k",
+    });
+  });
+
+  it("creates the file owner-only (0600)", () => {
+    const dir = freshDir();
+    const file = writeUserConfigFile({ COGNIGY_API_KEY: "secret" }, dir);
+    // Low 9 permission bits should be rw for owner only.
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("re-tightens permissions when overwriting an existing file", () => {
+    const dir = freshDir();
+    const file = join(dir, "config.json");
+    writeFileSync(file, "{}", { mode: 0o644 });
+    writeUserConfigFile({ COGNIGY_API_KEY: "secret" }, dir);
+    expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+});
+
+describe("readUserConfigFile", () => {
+  it("returns {} when the file is absent", () => {
+    const dir = freshDir();
+    expect(readUserConfigFile(join(dir, "config.json"))).toEqual({});
+  });
+
+  it("returns {} for malformed JSON", () => {
+    const dir = freshDir();
+    const file = join(dir, "config.json");
+    writeFileSync(file, "{ not json");
+    expect(readUserConfigFile(file)).toEqual({});
+  });
+
+  it("ignores non-string values and arrays", () => {
+    const dir = freshDir();
+    const file = join(dir, "config.json");
+    writeFileSync(
+      file,
+      JSON.stringify({ COGNIGY_API_KEY: "k", nested: { a: 1 }, n: 5 }),
+    );
+    expect(readUserConfigFile(file)).toEqual({ COGNIGY_API_KEY: "k" });
+
+    writeFileSync(file, JSON.stringify(["a", "b"]));
+    expect(readUserConfigFile(file)).toEqual({});
+  });
+});

--- a/src/__tests__/userConfigFile.test.ts
+++ b/src/__tests__/userConfigFile.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, afterEach } from "@jest/globals";
-import { mkdtempSync, rmSync, statSync, writeFileSync } from "fs";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { readUserConfigFile, writeUserConfigFile } from "../userConfigFile.js";
@@ -47,6 +54,15 @@ describe("writeUserConfigFile", () => {
     writeFileSync(file, "{}", { mode: 0o644 });
     writeUserConfigFile({ COGNIGY_API_KEY: "secret" }, dir);
     expect(statSync(file).mode & 0o777).toBe(0o600);
+  });
+
+  it("re-tightens a pre-existing directory to 0700", () => {
+    const parent = freshDir();
+    const dir = join(parent, "cfg");
+    mkdirSync(dir, { mode: 0o755 });
+    chmodSync(dir, 0o755); // umask can loosen mkdir's mode; force it broad
+    writeUserConfigFile({ COGNIGY_API_KEY: "secret" }, dir);
+    expect(statSync(dir).mode & 0o777).toBe(0o700);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,6 +4,7 @@
 import { readFileSync } from "fs";
 import { dirname, join } from "path";
 import { fileURLToPath } from "url";
+import { readUserConfigFile, USER_CONFIG_FILE } from "./userConfigFile.js";
 
 export interface Config {
   apiBaseUrl: string;
@@ -129,15 +130,31 @@ function parseIntWithDefault(
  * Load configuration from environment variables
  */
 export function loadConfig(): Config {
-  const apiBaseUrl = process.env.COGNIGY_API_BASE_URL;
-  const apiKey = process.env.COGNIGY_API_KEY;
+  // Environment variables win (terminal install stores them via userConfig /
+  // keychain). Only when one is missing do we consult the on-disk fallback
+  // written by the `cognigy-setup` CLI — this is the path GUI users take
+  // when their installer never prompted for credentials.
+  const fileConfig =
+    process.env.COGNIGY_API_BASE_URL && process.env.COGNIGY_API_KEY
+      ? {}
+      : readUserConfigFile();
+
+  const apiBaseUrl =
+    process.env.COGNIGY_API_BASE_URL || fileConfig.COGNIGY_API_BASE_URL;
+  const apiKey = process.env.COGNIGY_API_KEY || fileConfig.COGNIGY_API_KEY;
 
   if (!apiBaseUrl) {
-    throw new Error("COGNIGY_API_BASE_URL environment variable is required");
+    throw new Error(
+      `COGNIGY_API_BASE_URL is not set. Provide it via the plugin install prompt, ` +
+        `or run "npx @cognigy/plugin-engine cognigy-setup" to write ${USER_CONFIG_FILE}.`,
+    );
   }
 
   if (!apiKey) {
-    throw new Error("COGNIGY_API_KEY environment variable is required");
+    throw new Error(
+      `COGNIGY_API_KEY is not set. Provide it via the plugin install prompt, ` +
+        `or run "npx @cognigy/plugin-engine cognigy-setup" to write ${USER_CONFIG_FILE}.`,
+    );
   }
 
   const normalizedApiBaseUrl = normalizeApiBaseUrl(apiBaseUrl);

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
- * `cognigy-plugin setup` — interactive credential setup for clients whose plugin
+ * `cognigy-setup` — interactive credential setup for clients whose plugin
  * installer does not prompt for `userConfig` (e.g. the Claude Code GUI today).
+ * Exposed as the `cognigy-setup` bin: `npx @cognigy/plugin-engine cognigy-setup`.
  *
  * Collects the Cognigy API base URL and API key and writes them to
  * ~/.cognigy-plugin/config.json (owner-only, 0600). The engine's loadConfig()

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -1,0 +1,142 @@
+#!/usr/bin/env node
+/**
+ * `cognigy-plugin setup` — interactive credential setup for clients whose plugin
+ * installer does not prompt for `userConfig` (e.g. the Claude Code GUI today).
+ *
+ * Collects the Cognigy API base URL and API key and writes them to
+ * ~/.cognigy-plugin/config.json (owner-only, 0600). The engine's loadConfig()
+ * reads that file only when the matching env var is unset, so terminal users
+ * who already get a keychain prompt are unaffected.
+ *
+ * The API key prompt is masked and never echoed to the terminal or stored in a
+ * shell history. Non-interactive callers can pass --api-base-url / --api-key.
+ */
+import { createInterface } from "readline";
+import { writeUserConfigFile } from "./userConfigFile.js";
+
+const DEFAULT_BASE_URL = "https://api-trial.cognigy.ai";
+
+// Control codes handled during masked input.
+const CTRL_C = 3;
+const CTRL_D = 4;
+const BACKSPACE = 8;
+const DELETE = 127;
+
+interface Flags {
+  apiBaseUrl?: string;
+  apiKey?: string;
+}
+
+function parseFlags(argv: string[]): Flags {
+  const flags: Flags = {};
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    const take = () => argv[++i];
+    if (arg === "--api-base-url") flags.apiBaseUrl = take();
+    else if (arg.startsWith("--api-base-url="))
+      flags.apiBaseUrl = arg.slice("--api-base-url=".length);
+    else if (arg === "--api-key") flags.apiKey = take();
+    else if (arg.startsWith("--api-key="))
+      flags.apiKey = arg.slice("--api-key=".length);
+  }
+  return flags;
+}
+
+function ask(question: string): Promise<string> {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  return new Promise((resolve) => {
+    rl.question(question, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+/** Read a line without echoing it (masked with asterisks). */
+function askHidden(question: string): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const stdin = process.stdin;
+    process.stdout.write(question);
+    let value = "";
+    if (stdin.isTTY) stdin.setRawMode(true);
+    stdin.resume();
+    stdin.setEncoding("utf8");
+
+    const finish = (cleanup: () => void) => {
+      if (stdin.isTTY) stdin.setRawMode(false);
+      stdin.pause();
+      stdin.removeListener("data", onData);
+      process.stdout.write("\n");
+      cleanup();
+    };
+
+    const onData = (chunk: string) => {
+      for (const ch of chunk) {
+        const code = ch.charCodeAt(0);
+        if (ch === "\n" || ch === "\r" || code === CTRL_D) {
+          finish(() => resolve(value));
+          return;
+        }
+        if (code === CTRL_C) {
+          finish(() => reject(new Error("cancelled")));
+          return;
+        }
+        if (code === BACKSPACE || code === DELETE) {
+          if (value.length > 0) {
+            value = value.slice(0, -1);
+            process.stdout.write("\b \b");
+          }
+          continue;
+        }
+        value += ch;
+        process.stdout.write("*");
+      }
+    };
+
+    stdin.on("data", onData);
+  });
+}
+
+async function main(): Promise<void> {
+  const argv = process.argv.slice(2).filter((a) => a !== "setup");
+  const flags = parseFlags(argv);
+  const interactive = process.stdin.isTTY && flags.apiKey === undefined;
+
+  let apiBaseUrl = flags.apiBaseUrl;
+  let apiKey = flags.apiKey;
+
+  if (interactive) {
+    process.stdout.write("Cognigy Plugin setup\n\n");
+    const urlAnswer = await ask(`Cognigy API base URL [${DEFAULT_BASE_URL}]: `);
+    apiBaseUrl = urlAnswer || DEFAULT_BASE_URL;
+    apiKey = await askHidden("Cognigy API key: ");
+  } else {
+    // Non-interactive: values must come from flags.
+    apiBaseUrl = apiBaseUrl || DEFAULT_BASE_URL;
+  }
+
+  if (!apiKey) {
+    process.stderr.write(
+      "No API key provided. Pass --api-key <key> or run interactively.\n",
+    );
+    process.exit(1);
+  }
+
+  const file = writeUserConfigFile({
+    COGNIGY_API_BASE_URL: apiBaseUrl as string,
+    COGNIGY_API_KEY: apiKey,
+  });
+
+  process.stdout.write(`\n✓ Wrote ${file} (chmod 600)\n`);
+  process.stdout.write("Restart Claude Code to apply.\n");
+}
+
+main().catch((err) => {
+  const msg = err instanceof Error ? err.message : String(err);
+  if (msg === "cancelled") {
+    process.stderr.write("Cancelled.\n");
+    process.exit(130);
+  }
+  process.stderr.write(`Setup failed: ${msg}\n`);
+  process.exit(1);
+});

--- a/src/userConfigFile.ts
+++ b/src/userConfigFile.ts
@@ -49,9 +49,12 @@ export function writeUserConfigFile(
   dir: string = USER_CONFIG_DIR,
 ): string {
   mkdirSync(dir, { recursive: true, mode: 0o700 });
+  // mkdirSync's mode is ignored when the directory already exists, so
+  // re-tighten it in case a pre-existing dir had broader permissions.
+  chmodSync(dir, 0o700);
   const file = join(dir, "config.json");
   writeFileSync(file, `${JSON.stringify(values, null, 2)}\n`, { mode: 0o600 });
-  // writeFileSync's mode is ignored when the file already exists, so enforce it.
+  // writeFileSync's mode is likewise ignored when the file already exists.
   chmodSync(file, 0o600);
   return file;
 }

--- a/src/userConfigFile.ts
+++ b/src/userConfigFile.ts
@@ -1,0 +1,57 @@
+/**
+ * On-disk fallback config for clients whose plugin installer does not prompt
+ * for `userConfig` (e.g. the GUI app today). The `cognigy-plugin` setup CLI
+ * (src/setup.ts) writes this file; `loadConfig()` reads it only when the
+ * matching environment variable is absent, so the terminal/keychain path is
+ * never overridden.
+ *
+ * Keys mirror the environment variable names on purpose: the file is just a
+ * persisted set of "env vars" the engine would otherwise receive.
+ */
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export const USER_CONFIG_DIR = join(homedir(), ".cognigy-plugin");
+export const USER_CONFIG_FILE = join(USER_CONFIG_DIR, "config.json");
+
+export type UserConfigFile = Record<string, string>;
+
+/**
+ * Read the fallback config file. Returns `{}` when the file is absent or
+ * unreadable/malformed — callers treat a missing value the same as an unset
+ * env var, so a bad file must never throw during server boot.
+ */
+export function readUserConfigFile(
+  path: string = USER_CONFIG_FILE,
+): UserConfigFile {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(path, "utf-8"));
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+      const out: UserConfigFile = {};
+      for (const [k, v] of Object.entries(parsed as Record<string, unknown>)) {
+        if (typeof v === "string") out[k] = v;
+      }
+      return out;
+    }
+  } catch {
+    // Missing or malformed — behave as if nothing was configured.
+  }
+  return {};
+}
+
+/**
+ * Write the fallback config file with owner-only permissions (dir 0700,
+ * file 0600) so the API key is not world-readable. Returns the file path.
+ */
+export function writeUserConfigFile(
+  values: UserConfigFile,
+  dir: string = USER_CONFIG_DIR,
+): string {
+  mkdirSync(dir, { recursive: true, mode: 0o700 });
+  const file = join(dir, "config.json");
+  writeFileSync(file, `${JSON.stringify(values, null, 2)}\n`, { mode: 0o600 });
+  // writeFileSync's mode is ignored when the file already exists, so enforce it.
+  chmodSync(file, 0o600);
+  return file;
+}


### PR DESCRIPTION
## Problem

Installing the plugin from the **GUI** (desktop/web app) completes cleanly but does **not** show the `userConfig` credential prompt that the terminal install does. The MCP server then launches without `COGNIGY_API_BASE_URL` / `COGNIGY_API_KEY` and every tool call fails. Claude Code exposes no `claude plugin config set` CLI and the keychain naming for `sensitive` fields is undocumented, so there is no supported non-interactive way to populate the credentials.

## Solution

A `cognigy-setup` bin (run via `npx @cognigy/plugin-engine cognigy-setup`) that collects the two values and writes them to `~/.cognigy-plugin/config.json`:

- **API key entry is masked** (raw-mode, asterisks) — never echoed to the terminal or a shell history.
- File is written **owner-only** (dir `0700`, file `0600`), re-`chmod`ed on overwrite.
- `loadConfig()` reads the file **only when the matching env var is unset**, per-field — so the terminal keychain flow is untouched and env vars keep precedence.
- Non-interactive/scripted use: `--api-base-url` / `--api-key` flags.

The secret lives only in an owner-only file under `$HOME` — not in shared `~/.claude/settings.json` and not in any chat transcript.

## Changes

- `src/setup.ts` — interactive wizard + flags
- `src/userConfigFile.ts` — read/write helpers (tolerant read → `{}` on missing/malformed)
- `src/config.ts` — on-disk fallback + setup-guided error messages
- `package.json` — `bin: { cognigy-setup }`
- `README` — GUI install fallback section + Configuration note

## Testing

- `npx tsc --noEmit` clean; full suite green.
- New tests: `userConfigFile.test.ts` (write/read, `0600` perms incl. overwrite, malformed/array handling) and `config.test.ts` (env precedence, file fallback, per-field override, setup-guided errors).
- Packed the tarball, installed it into a scratch project, confirmed `node_modules/.bin/cognigy-setup` resolves and writes the file at `chmod 600`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)