### PR TITLE
fix(launcher): spawn npm with a shell on Windows to avoid EINVAL

### DIFF
--- a/plugin/bin/launch.mjs
+++ b/plugin/bin/launch.mjs
@@ -60,21 +60,34 @@ function installedVersion() {
 
 const current = installedVersion();
 if (current !== target) {
-  const npm = process.platform === "win32" ? "npm.cmd" : "npm";
-  const res = spawnSync(
-    npm,
-    [
-      "install",
-      `${PKG}@${target}`,
-      "--prefix",
-      dataDir,
-      "--no-fund",
-      "--no-audit",
-      "--loglevel=error",
-    ],
+  const isWin = process.platform === "win32";
+  const npm = isWin ? "npm.cmd" : "npm";
+  const rawArgs = [
+    "install",
+    `${PKG}@${target}`,
+    "--prefix",
+    dataDir,
+    "--no-fund",
+    "--no-audit",
+    "--loglevel=error",
+  ];
+  // On Windows npm is a .cmd shim, and since Node's CVE-2024-27980 fix
+  // (18.20.2 / 20.12.2+) child_process refuses to spawn .cmd/.bat without
+  // `shell: true` — it fails with EINVAL. With a shell, args are not
+  // auto-quoted, so quote any that contain spaces (e.g. a profile path).
+  const args = isWin
+    ? rawArgs.map((a) => (/[\s"]/.test(a) ? `"${a.replace(/"/g, '\\"')}"` : a))
+    : rawArgs;
+  const res = spawnSync(npm, args, {
     // stdout -> ignore (must stay clean for MCP); stderr -> inherit (show errors).
-    { stdio: ["ignore", "ignore", "inherit"] },
-  );
+    stdio: ["ignore", "ignore", "inherit"],
+    shell: isWin,
+  });
+  // spawnSync reports a spawn failure (e.g. EINVAL) via res.error, not stderr,
+  // so surface it explicitly — otherwise the only symptom is a silent -32000.
+  if (res.error) {
+    note(`npm install could not be spawned: ${res.error.message}`);
+  }
   if (res.status !== 0) {
     if (existsSync(engineEntry)) {
       note(


### PR DESCRIPTION
## Symptom

Windows users on Claude Code see the Cognigy MCP server fail to connect: `/plugin` → **"Failed to reconnect to plugin:cognigy:platform: -32000"**, `/plugins → Installed` shows the server **failed**. macOS is unaffected.

## Root cause

On first boot the launcher installs the pinned engine by spawning npm. On Windows that's `npm.cmd`. Since Node's fix for **CVE-2024-27980** (18.20.2 / 20.12.2+), `child_process` **refuses to spawn `.cmd`/`.bat` without `shell: true`** and fails with `EINVAL`.

So on a fresh Windows install (`current === null` → install runs):

1. `spawnSync("npm.cmd", …)` fails with `EINVAL` (returned in `res.error`, **not** on stderr).
2. The engine is never installed → `engineEntry` missing → launcher `exit(1)`.
3. The client reports the dead server process generically as `-32000`.

macOS/Linux spawn plain `npm` (no `.cmd`, no restriction), which is why it reproduces only on Windows and only on first boot.

Confirmed against a real report: Claude Code on Windows, `node …/cognigy/1.2.0/bin/launch.mjs`, status *failed*, `-32000`.

## Fix

- Pass `shell: process.platform === "win32"` to `spawnSync` so `npm.cmd` runs through `cmd.exe`.
- With a shell, args are not auto-quoted — quote any containing spaces (e.g. a Windows profile path with a space) to stay robust.
- Surface `res.error` via `note(...)`; spawn failures land there, not on stderr, so this class of failure was previously invisible (only the `-32000` showed).

## Testing

- `node --check` passes; full jest suite green (launcher isn't covered by jest — it's the plugin entry command, not engine code).
- macOS path is behaviorally unchanged: `isWin === false` → plain `npm`, `shell: false`, same args as before.
- I can't run Windows here — needs a confirming smoke test from a Windows user once released (fresh install → server connects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)