### PR TITLE
fix(installer): fix npx command, capitalize Desktop connector, add Windows guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ Detailed workflow guidance (agent creation, knowledge/RAG, voice, webchat, flow 
 
 In any terminal (requires [Node.js 20+](https://nodejs.org)):
 
+> **On Windows:** open the terminal **as Administrator** before running the command below.
+
 ```
 npx @cognigy/plugin-engine@latest cognigy-setup
 ```
@@ -53,6 +55,12 @@ npx @cognigy/plugin-engine@latest cognigy-setup
 Pick your client(s), enter your Cognigy API base URL (press Enter for the trial default) and API key (masked as you type), then restart the client.
 
 ✅ **Claude Code users — you're done.** You get the tools, skills, and agents.
+
+> **On Windows, after installing for Claude Desktop:** to make the connector appear:
+>
+> 1. **Fully restart** Claude Desktop — closing the window leaves it running in the system tray; quit it from there (or via Task Manager) so it actually relaunches.
+> 2. Check that the **Cognigy** connector now shows up under Settings → Connectors.
+> 3. If it does, **disable it and re-enable it once** — this forces a tool refresh so the Cognigy tools load.
 
 ### Step 2 — Claude Desktop chat only: finish in the app
 
@@ -65,12 +73,12 @@ Step 1 already wired the working connector, so **the tools work now**. To also g
 5. Install the **Cognigy** plugin by clicking **+**.
 6. On the warning about a local MCP, click **Continue**.
 
-Leave the plugin's own `platform` connector **unconnected** — the `cognigy` connector from Step 1 already serves the tools.
+Leave the plugin's own `platform` connector **unconnected** — the `Cognigy` connector from Step 1 already serves the tools.
 
 <details>
 <summary>Why the extra step on Claude Desktop? (for the technically curious)</summary>
 
-The plugin ships its own connector (`platform`), but on **Claude Desktop chat** it can't be given credentials — Desktop stores plugin config in your claude.ai account rather than a local file, and offers no field to enter the API key, so that connector stays a no-op. To make the tools work regardless, the Step 1 installer wires a **standalone `cognigy` connector** directly into `claude_desktop_config.json` (credentials stored there, `chmod 600`) behind an auto-updating, offline-safe launcher. The plugin install in Step 2 then adds only the parts Desktop _can_ deliver — the skills and agents. Claude Code has none of these limitations, which is why it's a single step.
+The plugin ships its own connector (`platform`), but on **Claude Desktop chat** it can't be given credentials — Desktop stores plugin config in your claude.ai account rather than a local file, and offers no field to enter the API key, so that connector stays a no-op. To make the tools work regardless, the Step 1 installer wires a **standalone `Cognigy` connector** directly into `claude_desktop_config.json` (credentials stored there, `chmod 600`) behind an auto-updating, offline-safe launcher. The plugin install in Step 2 then adds only the parts Desktop _can_ deliver — the skills and agents. Claude Code has none of these limitations, which is why it's a single step.
 
 </details>
 

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "type": "module",
   "bin": {
-    "cognigy-setup": "dist/setup.js",
-    "cognigy-mcp": "dist/index.js"
+    "cognigy-setup": "dist/setup.js"
   },
   "repository": {
     "type": "git",

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -99,7 +99,7 @@ describe("mergeDesktopConfig", () => {
 
   it("creates mcpServers when the file is absent", () => {
     const out = JSON.parse(mergeDesktopConfig(null, entry));
-    expect(out.mcpServers.cognigy).toEqual(entry);
+    expect(out.mcpServers.Cognigy).toEqual(entry);
   });
 
   it("preserves other servers and top-level keys", () => {
@@ -110,27 +110,27 @@ describe("mergeDesktopConfig", () => {
     const out = JSON.parse(mergeDesktopConfig(existing, entry));
     expect(out.globalShortcut).toBe("Cmd+Space");
     expect(out.mcpServers.other).toEqual({ command: "x", args: [] });
-    expect(out.mcpServers.cognigy).toEqual(entry);
+    expect(out.mcpServers.Cognigy).toEqual(entry);
   });
 
-  it("overwrites a stale cognigy entry in place", () => {
+  it("overwrites a stale Cognigy entry in place", () => {
     const existing = JSON.stringify({
-      mcpServers: { cognigy: { command: "old", args: ["old"], env: {} } },
+      mcpServers: { Cognigy: { command: "old", args: ["old"], env: {} } },
     });
     const out = JSON.parse(mergeDesktopConfig(existing, entry));
-    expect(out.mcpServers.cognigy).toEqual(entry);
+    expect(out.mcpServers.Cognigy).toEqual(entry);
   });
 
   it("treats malformed JSON as empty (caller backs up first)", () => {
     const out = JSON.parse(mergeDesktopConfig("{ not json", entry));
-    expect(out.mcpServers.cognigy).toEqual(entry);
+    expect(out.mcpServers.Cognigy).toEqual(entry);
   });
 
   it("ignores a non-object mcpServers", () => {
     const out = JSON.parse(
       mergeDesktopConfig(JSON.stringify({ mcpServers: ["x"] }), entry),
     );
-    expect(out.mcpServers.cognigy).toEqual(entry);
+    expect(out.mcpServers.Cognigy).toEqual(entry);
   });
 });
 
@@ -244,6 +244,19 @@ describe("isMainModule", () => {
     const moduleUrl = pathToFileURL(real).href;
     expect(isMainModule(moduleUrl, join(dir, "nonexistent"))).toBe(false);
     expect(isMainModule(moduleUrl, undefined)).toBe(false);
+  });
+});
+
+describe("package.json bin", () => {
+  it("declares exactly one bin so `npx <pkg> cognigy-setup` resolves", () => {
+    // npx treats a positional after the package as an ARG to the default bin,
+    // not a bin selector. With one bin npx runs it; a second bin makes npx
+    // need a default named after the (scope-stripped) package, which we don't
+    // have, so `npx @cognigy/plugin-engine@latest cognigy-setup` throws
+    // "could not determine executable to run". Keep it to one bin.
+    const pkgPath = join(process.cwd(), "package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8"));
+    expect(Object.keys(pkg.bin)).toEqual(["cognigy-setup"]);
   });
 });
 

--- a/src/__tests__/installClaudeDesktop.test.ts
+++ b/src/__tests__/installClaudeDesktop.test.ts
@@ -61,10 +61,10 @@ describe("installClaudeDesktop", () => {
 
     // Config written with our server entry, owner-only.
     const cfg = JSON.parse(readFileSync(configPath, "utf8"));
-    expect(cfg.mcpServers.cognigy.args).toEqual([
+    expect(cfg.mcpServers.Cognigy.args).toEqual([
       join(FAKE_HOME, "desktop-launch.mjs"),
     ]);
-    expect(cfg.mcpServers.cognigy.env.COGNIGY_API_KEY).toBe("secret-key");
+    expect(cfg.mcpServers.Cognigy.env.COGNIGY_API_KEY).toBe("secret-key");
     expect(statSync(configPath).mode & 0o777).toBe(0o600);
     expect(result.backupPath).toBeUndefined();
   });
@@ -82,7 +82,7 @@ describe("installClaudeDesktop", () => {
     expect(existsSync(result.backupPath as string)).toBe(true);
     const cfg = JSON.parse(readFileSync(configPath, "utf8"));
     expect(cfg.mcpServers.other).toEqual({ command: "x", args: [] });
-    expect(cfg.mcpServers.cognigy).toBeDefined();
+    expect(cfg.mcpServers.Cognigy).toBeDefined();
   });
 
   it("keeps the first pristine backup across re-runs", () => {
@@ -96,7 +96,7 @@ describe("installClaudeDesktop", () => {
     installClaudeDesktop(CREDS, configPath); // must NOT clobber the .bak
 
     const backup = JSON.parse(readFileSync(`${configPath}.bak`, "utf8"));
-    expect(backup.mcpServers.cognigy).toBeUndefined(); // still the pristine file
+    expect(backup.mcpServers.Cognigy).toBeUndefined(); // still the pristine file
     expect(backup.mcpServers.other).toEqual({ command: "x" });
   });
 

--- a/src/install/claudeDesktop.ts
+++ b/src/install/claudeDesktop.ts
@@ -31,6 +31,8 @@ import {
 
 const PKG = "@cognigy/plugin-engine";
 export const ENGINE_PREFIX = join(USER_HOME_DIR, "engine");
+/** mcpServers key for our entry. Capitalized so Desktop shows "Cognigy". */
+export const SERVER_KEY = "Cognigy";
 
 export interface DesktopServerEntry {
   command: string;
@@ -108,7 +110,7 @@ export function mergeDesktopConfig(
     !Array.isArray(existingServers)
       ? (existingServers as Record<string, unknown>)
       : {};
-  root.mcpServers = { ...servers, cognigy: entry };
+  root.mcpServers = { ...servers, [SERVER_KEY]: entry };
   return `${JSON.stringify(root, null, 2)}\n`;
 }
 

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -297,14 +297,26 @@ function runInstall(client: Client, creds: UserConfigFile): void {
   const res = installClaudeDesktop(creds);
   process.stdout.write(
     green("\n✓ Claude Desktop") +
-      `: 'cognigy' connector added to ${res.configPath}\n` +
+      `: 'Cognigy' connector added to ${res.configPath}\n` +
       (res.backupPath
         ? dim(`  (backed up existing config to ${res.backupPath})\n`)
         : "") +
-      "  Restart Claude Desktop — the 'cognigy' connector gives you the " +
+      "  Restart Claude Desktop — the 'Cognigy' connector gives you the " +
       bold("tools") +
       ".\n",
   );
+  // Windows Desktop needs a firmer restart + a tool-refresh nudge, else the
+  // connector either doesn't appear or appears with no tools loaded.
+  if (process.platform === "win32") {
+    process.stdout.write(
+      "\n" +
+        cyan(bold("  Windows — make the connector appear:\n")) +
+        `    ${cyan("•")} If this run hit a permissions error, re-run it in a terminal opened ${bold("as Administrator")}.\n` +
+        `    ${cyan("•")} ${bold("Fully quit")} Claude Desktop from the system tray (closing the window leaves it running), then reopen it.\n` +
+        `    ${cyan("•")} Confirm the ${bold("cognigy")} connector shows under Settings → Connectors.\n` +
+        `    ${cyan("•")} Then ${bold("disable it and re-enable it once")} to force a tool refresh.\n`,
+    );
+  }
   // A loud, unmissable block: on Desktop chat, skills + agents come ONLY from
   // these manual in-app steps. Without them the user has tools and nothing else.
   process.stdout.write(
@@ -328,7 +340,7 @@ function runInstall(client: Client, creds: UserConfigFile): void {
       `    ${cyan("6.")} On the local-MCP warning, click ${bold("Continue")}.\n\n` +
       dim(
         "  Leave the plugin's own 'platform' connector unconnected — the\n" +
-          "  'cognigy' connector already serves the tools.\n",
+          "  'Cognigy' connector already serves the tools.\n",
       ) +
       yellow(RULE) +
       "\n",

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -313,7 +313,7 @@ function runInstall(client: Client, creds: UserConfigFile): void {
         cyan(bold("  Windows — make the connector appear:\n")) +
         `    ${cyan("•")} If this run hit a permissions error, re-run it in a terminal opened ${bold("as Administrator")}.\n` +
         `    ${cyan("•")} ${bold("Fully quit")} Claude Desktop from the system tray (closing the window leaves it running), then reopen it.\n` +
-        `    ${cyan("•")} Confirm the ${bold("cognigy")} connector shows under Settings → Connectors.\n` +
+        `    ${cyan("•")} Confirm the ${bold("Cognigy")} connector shows under Settings → Connectors.\n` +
         `    ${cyan("•")} Then ${bold("disable it and re-enable it once")} to force a tool refresh.\n`,
     );
   }


### PR DESCRIPTION
## Why

A Windows user hit `npm error could not determine executable to run` when running the documented install command:

```
npx @cognigy/plugin-engine@latest cognigy-setup
```

Root cause: we recently added a second bin (`cognigy-mcp`). `npx <pkg> cognigy-setup` treats `cognigy-setup` as an **argument to the default bin**, not a bin selector — with one bin npx runs it, but with two bins and neither named after the scope-stripped package (`plugin-engine`), npm's `getBinFromManifest` throws. `npx -p @cognigy/plugin-engine cognigy-setup` still worked, which is what tipped us off.

This PR restores the documented command and folds in two related fixes surfaced during the same Windows test.

## What

- **Drop the `cognigy-mcp` bin.** It was wired into nothing (Desktop uses the launcher `.mjs`, the plugin uses `plugin/bin/launch.mjs`); it existed only as a "run the server by command" convenience. Removing it restores the single-bin default so the documented `npx … cognigy-setup` resolves. Added a regression test asserting exactly one bin.
- **Capitalize the Desktop connector key** `cognigy` → `Cognigy` in `claude_desktop_config.json` so it reads properly in the app. Hard rename, no legacy migration (no real users yet).
- **Windows install guidance** (README + setup CLI), from a tester's working recipe:
  - Run the installer in a terminal opened **as Administrator**.
  - After install: **fully restart** Claude Desktop (quit from the system tray — closing the window leaves it running), verify the **Cognigy** connector appears, then **disable/re-enable it once** to force a tool refresh.

## Testing

- `npx tsc -p tsconfig.json --noEmit` clean.
- Full Jest suite green (372 passed). New tests: single-bin guard, `Cognigy` key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)