### PR TITLE
fix(config): derive endpoint/webchat/static URLs for prefixed tenant …

### DIFF
--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -79,6 +79,22 @@ describe("loadConfig", () => {
     expect(config.webchatBaseUrl).toBe("https://webchat-trial.cognigy.ai");
   });
 
+  it("derives endpoint/static/webchat URLs from a tenant host with a prefixed api- segment", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://cognigy-api-na1.nicecxone.com";
+    process.env.COGNIGY_API_KEY = "test-key";
+    const config = loadConfig();
+    expect(config.apiBaseUrl).toBe("https://cognigy-api-na1.nicecxone.com");
+    expect(config.endpointBaseUrl).toBe(
+      "https://cognigy-endpoint-na1.nicecxone.com",
+    );
+    expect(config.webchatBaseUrl).toBe(
+      "https://cognigy-webchat-na1.nicecxone.com",
+    );
+    expect(config.staticFilesBaseUrl).toBe(
+      "https://cognigy-static-na1.nicecxone.com",
+    );
+  });
+
   it("uses explicit COGNIGY_ENDPOINT_BASE_URL if provided", () => {
     process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
     process.env.COGNIGY_API_KEY = "test-key";

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -95,6 +95,15 @@ describe("loadConfig", () => {
     );
   });
 
+  it("does not match 'api-' occurring mid-segment instead of at a segment boundary", () => {
+    process.env.COGNIGY_API_BASE_URL = "https://myapi-dev.example.com";
+    process.env.COGNIGY_API_KEY = "test-key";
+    const config = loadConfig();
+    expect(config.endpointBaseUrl).toBe("https://myapi-dev.example.com");
+    expect(config.webchatBaseUrl).toBe("https://myapi-dev.example.com");
+    expect(config.staticFilesBaseUrl).toBe("https://myapi-dev.example.com");
+  });
+
   it("uses explicit COGNIGY_ENDPOINT_BASE_URL if provided", () => {
     process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
     process.env.COGNIGY_API_KEY = "test-key";

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,20 +59,30 @@ function normalizeApiBaseUrl(raw: string): string {
 }
 
 /**
- * Derive the endpoint base URL from the API base URL.
- * Pattern: https://api-{env}.cognigy.ai -> https://endpoint-{env}.cognigy.ai
+ * Derive a sibling base URL from the API base URL by swapping the "api-"
+ * segment of the hostname for another one (e.g. "endpoint-", "static-").
+ * Handles both bare hosts (api-dev.cognigy.ai) and prefixed tenant hosts
+ * (cognigy-api-na1.nicecxone.com -> cognigy-endpoint-na1.nicecxone.com).
  */
-function deriveEndpointBaseUrl(apiBaseUrl: string): string {
+function deriveHostBaseUrl(apiBaseUrl: string, replacement: string): string {
   try {
     const url = new URL(apiBaseUrl);
-    const match = url.hostname.match(/^api-(.+)$/);
+    const match = url.hostname.match(/^(.*?)api-(.+)$/);
     if (match) {
-      return `${url.protocol}//endpoint-${match[1]}`;
+      return `${url.protocol}//${match[1]}${replacement}-${match[2]}`;
     }
   } catch {
     // fall through
   }
-  return apiBaseUrl.replace(/\/api-/, "/endpoint-");
+  return apiBaseUrl.replace(/api-/, `${replacement}-`);
+}
+
+/**
+ * Derive the endpoint base URL from the API base URL.
+ * Pattern: https://api-{env}.cognigy.ai -> https://endpoint-{env}.cognigy.ai
+ */
+function deriveEndpointBaseUrl(apiBaseUrl: string): string {
+  return deriveHostBaseUrl(apiBaseUrl, "endpoint");
 }
 
 /**
@@ -80,16 +90,7 @@ function deriveEndpointBaseUrl(apiBaseUrl: string): string {
  * Pattern: https://api-{env}.cognigy.ai -> https://static-{env}.cognigy.ai
  */
 function deriveStaticFilesBaseUrl(apiBaseUrl: string): string {
-  try {
-    const url = new URL(apiBaseUrl);
-    const match = url.hostname.match(/^api-(.+)$/);
-    if (match) {
-      return `${url.protocol}//static-${match[1]}`;
-    }
-  } catch {
-    // fall through
-  }
-  return apiBaseUrl.replace(/\/api-/, "/static-");
+  return deriveHostBaseUrl(apiBaseUrl, "static");
 }
 
 /**
@@ -97,16 +98,7 @@ function deriveStaticFilesBaseUrl(apiBaseUrl: string): string {
  * Pattern: https://api-{env}.cognigy.ai -> https://webchat-{env}.cognigy.ai
  */
 function deriveWebchatBaseUrl(apiBaseUrl: string): string {
-  try {
-    const url = new URL(apiBaseUrl);
-    const match = url.hostname.match(/^api-(.+)$/);
-    if (match) {
-      return `${url.protocol}//webchat-${match[1]}`;
-    }
-  } catch {
-    // fall through
-  }
-  return apiBaseUrl.replace(/\/api-/, "/webchat-");
+  return deriveHostBaseUrl(apiBaseUrl, "webchat");
 }
 
 const VALID_LOG_LEVELS = new Set<string>(["debug", "info", "warn", "error"]);

--- a/src/config.ts
+++ b/src/config.ts
@@ -67,14 +67,16 @@ function normalizeApiBaseUrl(raw: string): string {
 function deriveHostBaseUrl(apiBaseUrl: string, replacement: string): string {
   try {
     const url = new URL(apiBaseUrl);
-    const match = url.hostname.match(/^(.*?)api-(.+)$/);
-    if (match) {
-      return `${url.protocol}//${match[1]}${replacement}-${match[2]}`;
-    }
+    url.hostname = url.hostname.replace(/(^|-)api-/, `$1${replacement}-`);
+    return `${url.protocol}//${url.hostname}`;
   } catch {
-    // fall through
+    // Not a parseable URL: fall back to a host-scoped replace on the
+    // scheme://host portion only, leaving any path/query untouched.
+    const schemeMatch = apiBaseUrl.match(/^([a-z]+:\/\/)([^/?#]*)(.*)$/i);
+    if (!schemeMatch) return apiBaseUrl;
+    const [, scheme, host, rest] = schemeMatch;
+    return `${scheme}${host.replace(/(^|-)api-/, `$1${replacement}-`)}${rest}`;
   }
-  return apiBaseUrl.replace(/api-/, `${replacement}-`);
 }
 
 /**


### PR DESCRIPTION
deriveEndpointBaseUrl and friends only matched hostnames starting with "api-" (api-dev.cognigy.ai), so tenant hosts like
cognigy-api-na1.nicecxone.com fell through unchanged, pointing talk_to_agent and endpoint creation at the wrong host.

## Summary

- Fixed `deriveEndpointBaseUrl`/`deriveWebchatBaseUrl`/`deriveStaticFilesBaseUrl` to correctly derive sibling URLs for tenant hosts where `api-` is a mid-hostname segment (e.g. `cognigy-api-na1.nicecxone.com`), not just a leading prefix (`api-dev.cognigy.ai`)
- Consolidated the three near-duplicate derivation functions into a single `deriveHostBaseUrl(apiBaseUrl, replacement)` helper
- Added a regression test covering the tenant-host pattern

## Changes

| File / Component                    | Description                                                                                                                   |
| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
| `src/config.ts`                     | Replaced the `^api-(.+)$` hostname regex (prefix-only match) with `^(.*?)api-(.+)$` in a shared `deriveHostBaseUrl` helper, so any `api-` segment in the hostname is swapped while preserving surrounding text (e.g. `cognigy-` prefix) |
| `src/__tests__/config.test.ts`      | Added a test asserting `endpointBaseUrl`/`webchatBaseUrl`/`staticFilesBaseUrl` derive correctly from `https://cognigy-api-na1.nicecxone.com`                                                                       |

## Test plan

Automated:

- `npm test -- --runInBand config` — all config tests pass (pre-existing unrelated failures in `userConfigFile.test.ts` are Windows file-permission-bit issues, not affected by this change)
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm run prettier:check -- src/config.ts src/__tests__/config.test.ts`

Manual:

- Ran `handleTalkToAgent` locally against a real tenant with `COGNIGY_API_BASE_URL=https://cognigy-api-na1.nicecxone.com`; confirmed the resolved `endpointUrl` now correctly derives to `https://cognigy-endpoint-na1.nicecxone.com/...` (matching the tenant's actual endpoint host) and the agent responds successfully, instead of resolving to the wrong host

## Breaking changes / migration

- None

## Marketplace checklist

- [x] Versions left untouched — `package.json` and `plugin/.claude-plugin/plugin.json` are synced automatically by semantic-release on merge (`scripts/sync-plugin-version.mjs`); do not hand-edit either `version`
- [x] Tool count in `README.md` updated if the tool surface changed — N/A, no tool surface change
- [x] `README.md` updated if user-facing behavior changed — N/A, internal URL-derivation fix only
- [x] Tool annotations/descriptions reviewed if tool behavior changed — N/A, no tool behavior change
- [x] `LICENSE` / marketplace metadata reviewed if submission requirements are affected — N/A
