### PR TITLE
feat(plugin): bundle Cognigy docs MCP server + docs-lookup steering

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ A plugin that connects your AI assistant to the [Cognigy.AI](https://www.cognigy
 - **Browser voice deployment**: create Voice Gateway endpoints with WebRTC demo URLs
 - **Voice preview setup**: configure supported speech providers for voice experiences
 - **Skills + agents**: workflow guidance auto-loads as skills in supporting clients; build/go-live loops run as subagents
+- **Built-in docs lookup**: bundles the official [Cognigy documentation](https://docs.cognigy.com) MCP server — your assistant searches and reads the docs before answering platform questions, instead of guessing from training data
 - Built-in rate limiting, Zod input validation, and RFC 7807 error responses
 
 ## Tools

--- a/plugin/.claude-plugin/plugin.json
+++ b/plugin/.claude-plugin/plugin.json
@@ -34,6 +34,10 @@
         "COGNIGY_API_BASE_URL": "${user_config.cognigy_api_base_url}",
         "COGNIGY_API_KEY": "${user_config.cognigy_api_key}"
       }
+    },
+    "docs": {
+      "type": "http",
+      "url": "https://docs.cognigy.com/mcp"
     }
   }
 }

--- a/plugin/skills/docs-lookup/SKILL.md
+++ b/plugin/skills/docs-lookup/SKILL.md
@@ -15,9 +15,9 @@ The plugin bundles the official Cognigy documentation MCP server (docs.cognigy.c
 
 ## Workflow
 
-1. Search first: `search_cognigy_documentation` with the user's question rephrased as a docs query.
-2. Excerpt not enough → read the page: `head -200 /<path>.mdx` via the filesystem tool.
-3. Exact string hunting (error messages, config keys, node names) → `rg` via the filesystem tool instead of search.
+1. Search first: `search_cognigy_documentation { query: "<user's question rephrased as a docs query>" }`.
+2. Excerpt not enough → read the page: `query_docs_filesystem_cognigy_documentation { command: "head -200 /<path>.mdx" }`. These commands run inside the MCP tool's virtual docs filesystem — never in the local shell.
+3. Exact string hunting (error messages, config keys, node names) → `query_docs_filesystem_cognigy_documentation { command: "rg -il '<term>' /" }` instead of search.
 4. Answer from what the docs say, cite the page link. If docs and observed API behavior conflict, say so explicitly — the plugin's own skills (flow-nodes, troubleshooting) capture hard-won API gotchas the public docs may not cover.
 
 ## When NOT to use

--- a/plugin/skills/docs-lookup/SKILL.md
+++ b/plugin/skills/docs-lookup/SKILL.md
@@ -1,0 +1,26 @@
+---
+name: docs-lookup
+description: "Use when the user asks how a Cognigy.AI feature, node, endpoint, setting, or concept works, asks for Cognigy documentation, best practices, or release/version behavior, or when you are unsure of platform behavior or valid configuration values and need to consult the official docs before answering or building."
+---
+
+# Cognigy Docs Lookup
+
+The plugin bundles the official Cognigy documentation MCP server (docs.cognigy.com). Use it as the source of truth for platform questions — the platform changes faster than model training data. Prefer documented answers over prior knowledge, and link the doc page you used.
+
+## Tools
+
+- `search_cognigy_documentation` — semantic search over the full docs site. Returns excerpts with titles and page links. Start here for conceptual questions ("how does handover work", "what is a lexicon").
+- `query_docs_filesystem_cognigy_documentation` — read-only shell-like queries (`rg`, `cat`, `head`, `tree`, `ls`) over a virtual filesystem of every docs page (`.mdx`) plus OpenAPI specs. Use for exact keyword/regex matches, reading a full page (append `.mdx` to the path returned by search), or exploring docs structure.
+- `submit_feedback` — report incorrect, outdated, or confusing docs to the Cognigy docs team. Offer this when you and the user hit a genuine documentation gap.
+
+## Workflow
+
+1. Search first: `search_cognigy_documentation` with the user's question rephrased as a docs query.
+2. Excerpt not enough → read the page: `head -200 /<path>.mdx` via the filesystem tool.
+3. Exact string hunting (error messages, config keys, node names) → `rg` via the filesystem tool instead of search.
+4. Answer from what the docs say, cite the page link. If docs and observed API behavior conflict, say so explicitly — the plugin's own skills (flow-nodes, troubleshooting) capture hard-won API gotchas the public docs may not cover.
+
+## When NOT to use
+
+- Plugin/tool mechanics (which MCP tool to call, tool arguments) — that is this plugin's own skills, not the public docs.
+- Live project state (what agents/flows exist) — use `list_resources` / `get_resource`.

--- a/plugin/skills/docs-lookup/SKILL.md
+++ b/plugin/skills/docs-lookup/SKILL.md
@@ -9,7 +9,7 @@ The plugin bundles the official Cognigy documentation MCP server (docs.cognigy.c
 
 ## Tools
 
-- `search_cognigy_documentation` — semantic search over the full docs site. Returns excerpts with titles and page links. Start here for conceptual questions ("how does handover work", "what is a lexicon").
+- `search_cognigy_documentation` — semantic search over the full docs site. Returns excerpts with titles and page links. Start here for conceptual questions ("how does handover work", "what is a lexicon"). WARNING: results can be very large (100KB+) and may overflow the tool-result limit — when the result lands in a file, triage it (e.g. extract the `Title:`/`Page:` lines) instead of reading it whole, then read the one or two best pages via the filesystem tool. For narrow questions (a specific config key, node name, error string), skip search and use `rg` on the filesystem tool directly.
 - `query_docs_filesystem_cognigy_documentation` — read-only shell-like queries (`rg`, `cat`, `head`, `tree`, `ls`) over a virtual filesystem of every docs page (`.mdx`) plus OpenAPI specs. Use for exact keyword/regex matches, reading a full page (append `.mdx` to the path returned by search), or exploring docs structure.
 - `submit_feedback` — report incorrect, outdated, or confusing docs to the Cognigy docs team. Offer this when you and the user hit a genuine documentation gap.
 

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -15,7 +15,7 @@ TOOL TYPE SELECTION (create_tool):
 - Use toolType "send_email" when the user wants to send emails.
 
 DOCUMENTATION LOOKUP:
-- The plugin also bundles the official Cognigy docs MCP server (docs.cognigy.com). When the user asks how a Cognigy.AI feature, node, endpoint, or setting works — or you are unsure of platform behavior, valid config values, or terminology — search the docs (search_cognigy_documentation) BEFORE answering from memory or guessing. Read full pages via the docs filesystem tool when the search excerpt is not enough. Prefer documented answers over prior knowledge; the platform changes faster than model training data.
+- The plugin also bundles the official Cognigy docs MCP server (docs.cognigy.com). When the user asks how a Cognigy.AI feature, node, endpoint, or setting works — or you are unsure of platform behavior, valid config values, or terminology — search the docs (search_cognigy_documentation) BEFORE answering from memory or guessing. Read full pages via query_docs_filesystem_cognigy_documentation (an MCP tool running shell-like read commands against a virtual docs filesystem — NOT the local shell) when the search excerpt is not enough. Prefer documented answers over prior knowledge; the platform changes faster than model training data.
 
 RULES:
 - create_ai_agent auto-provisions flow + AI Agent Job Node + REST endpoint. Do NOT create these separately.

--- a/src/instructions.ts
+++ b/src/instructions.ts
@@ -14,6 +14,9 @@ TOOL TYPE SELECTION (create_tool):
 - Use toolType "knowledge" when the user wants to search a Knowledge Store.
 - Use toolType "send_email" when the user wants to send emails.
 
+DOCUMENTATION LOOKUP:
+- The plugin also bundles the official Cognigy docs MCP server (docs.cognigy.com). When the user asks how a Cognigy.AI feature, node, endpoint, or setting works — or you are unsure of platform behavior, valid config values, or terminology — search the docs (search_cognigy_documentation) BEFORE answering from memory or guessing. Read full pages via the docs filesystem tool when the search excerpt is not enough. Prefer documented answers over prior knowledge; the platform changes faster than model training data.
+
 RULES:
 - create_ai_agent auto-provisions flow + AI Agent Job Node + REST endpoint. Do NOT create these separately.
 - An LLM resource MUST exist AND be successfully connected in the project before calling talk_to_agent. Do NOT test an agent without a confirmed working LLM — it fails silently or returns empty responses. If LLM setup failed or was not completed, skip testing and inform the user.


### PR DESCRIPTION
## What

Wires the official Cognigy documentation MCP server (https://docs.cognigy.com/mcp, Mintlify-hosted, streamable HTTP, no auth) into the plugin, plus steering so the model actually uses it.

- **`plugin/.claude-plugin/plugin.json`** — second `mcpServers` entry `docs` pointing at the remote server. Every plugin session gets live docs search (`search_cognigy_documentation`), full-page reads via the virtual docs filesystem tool (`rg`/`cat`/`head`/`tree` over all `.mdx` pages + OpenAPI specs), and `submit_feedback`.
- **`src/instructions.ts`** — always-on DOCUMENTATION LOOKUP rule: search the docs before answering platform questions from memory. Matters most for clients without skill support (Codex, Desktop connector).
- **`plugin/skills/docs-lookup/SKILL.md`** — intent-triggered skill for Claude Code: search first, read full pages, `rg` for exact strings, cite the page, offer `submit_feedback` on genuine doc gaps.

## Why

Platform guidance previously came from model training data — stale by definition. The docs server keeps answers current with the published documentation and links sources. Docs server self-describes at handshake, but nothing pushed the model to prefer it over prior knowledge; the instructions rule + skill close that gap.

## Notes

- `scripts/sync-plugin-version.mjs` only rewrites the top-level `version` and the `@cognigy/plugin-engine` pin inside the `platform` entry — verified with a dry-run bump that the new `docs` entry is untouched by releases.
- Remote HTTP entry is manifest-only (no scripts), so it does not trip Desktop's marketplace file scan.
- Claude Desktop's installer-wired connector is stdio-only; Desktop users get docs tools via the plugin (or a custom connector URL). An `mcp-remote` shim in the installer is a possible follow-up.

## Testing

- `npx tsc -p tsconfig.json --noEmit` — clean
- Prettier — clean
- Probed the endpoint: MCP initialize handshake + `tools/list` verified live (3 tools)
- Dry-run `sync-plugin-version.mjs 9.9.9-test` — bumps version + engine pin only, `docs` entry untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)