### PR TITLE
feat(tools): support OpenAI-compatible LLM providers in setup_llm

### DIFF
--- a/plugin/skills/llm-providers/SKILL.md
+++ b/plugin/skills/llm-providers/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: llm-providers
-description: "Use when configuring or choosing an LLM for a Cognigy agent — valid provider names (openAI, anthropic, azureOpenAI, google, mistral), model strings, connection types, and credential resolution."
+description: "Use when configuring or choosing an LLM for a Cognigy agent — valid provider names (openAI, anthropic, azureOpenAI, google, mistral, openAICompatible), model strings, connection types, credential resolution, and OpenAI-compatible endpoints (vLLM, Hugging Face, LiteLLM, Azure AI Foundry, self-hosted)."
 ---
 
 # LLM Provider Reference
@@ -14,6 +14,7 @@ description: "Use when configuring or choosing an LLM for a Cognigy agent — va
 | azureOpenAI | gpt-4o (deployment name)                                   | AzureOpenAIProviderV2  | Requires apiKey, may need connectionId with deployment config |
 | google      | gemini-2.0-flash, gemini-1.5-pro                           | GoogleVertexAIProvider | Requires apiKey                                               |
 | mistral     | mistral-small-2503, mistral-medium-latest                  | MistralProvider        | Requires apiKey                                               |
+| openAICompatible | custom-model, custom-embedding-model                  | OpenAICompatibleProvider | Requires apiKey + baseCustomUrl + customModel (see below)   |
 
 ## Model groups
 
@@ -27,6 +28,40 @@ description: "Use when configuring or choosing an LLM for a Cognigy agent — va
 Chat/completion models are not embedding models. `gpt-4o-mini` is a chat model, not a valid embedding-model choice for knowledge-store indexing.
 
 When using `list_resources { resourceType: "llm_model", projectId }`, inspect the returned `modelType` and select the model by its exact role. Do not infer that all LLMs are interchangeable.
+
+## OpenAI-compatible providers (openAICompatible)
+
+Use provider `openAICompatible` for ANY endpoint that speaks the OpenAI API but is not OpenAI itself: vLLM, Hugging Face, LiteLLM, Groq, Together AI, Azure AI Foundry (model router), or self-hosted deployments. Do NOT mislabel these as `openAI` — without a base URL the connection test hits api.openai.com and fails.
+
+Required parameters:
+
+- `modelType`: exactly `custom-model` (chat) or `custom-embedding-model` (embedding) — never the real model name
+- `customModel`: the model name as known by the provider, e.g. `llama-3.3-70b-instruct`
+- `baseCustomUrl`: the provider's OpenAI-compatible base URL, e.g. `https://my-llm-host.example.com/v1`
+- `apiKey` (or a same-project `connectionId`)
+
+Optional parameters:
+
+- `customAuthHeader`: custom HTTP header name for authentication (e.g. `Ocp-Apim-Subscription-Key`). When set, the API key is sent in that header instead of `Authorization: Bearer <key>`.
+- `apiType`: `chatCompletion` (default) or `responses` — only use `responses` if the provider supports OpenAI's Responses API.
+
+Example:
+
+```json
+{
+  "projectId": "<projectId>",
+  "provider": "openAICompatible",
+  "modelType": "custom-model",
+  "customModel": "llama-3.3-70b-instruct",
+  "baseCustomUrl": "https://my-llm-host.example.com/v1",
+  "apiKey": "<key>"
+}
+```
+
+Notes:
+
+- The Completions API for custom LLMs is deprecated (removal planned for Cognigy.AI 2026.24.0) — use Chat Completions or Responses.
+- When inspecting existing models via `list_resources` / `get_resource`, openAI-compatible models show `modelType: "custom-model"`; the real model name and endpoint are in the `openAICompatible` object (`customModel`, `baseCustomUrl`, `customAuthHeader`).
 
 ## Credential resolution
 

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -218,6 +218,108 @@ describe("setupLlmSchema", () => {
     });
     expect(result.dangerouslySkipConnectionTest).toBeUndefined();
   });
+
+  it("accepts a full openAICompatible input", () => {
+    const result = schemas.setupLlmSchema.parse({
+      projectId: VALID_ID,
+      provider: "openAICompatible",
+      modelType: "custom-model",
+      customModel: "llama-3.3-70b-instruct",
+      baseCustomUrl: "https://llm.example.com/v1",
+      customAuthHeader: "X-Custom-Auth",
+      apiType: "chatCompletion",
+      apiKey: "key-123",
+    });
+    expect(result.provider).toBe("openAICompatible");
+    expect(result.customModel).toBe("llama-3.3-70b-instruct");
+  });
+
+  it("accepts openAICompatible with custom-embedding-model", () => {
+    const result = schemas.setupLlmSchema.parse({
+      projectId: VALID_ID,
+      provider: "openAICompatible",
+      modelType: "custom-embedding-model",
+      customModel: "bge-large-en-v1.5",
+      baseCustomUrl: "https://llm.example.com/v1",
+      apiKey: "key-123",
+    });
+    expect(result.modelType).toBe("custom-embedding-model");
+  });
+
+  it("rejects openAICompatible without baseCustomUrl", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        customModel: "llama-3.3-70b-instruct",
+        apiKey: "key-123",
+      }),
+    ).toThrow(/baseCustomUrl/);
+  });
+
+  it("rejects openAICompatible without customModel", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiKey: "key-123",
+      }),
+    ).toThrow(/customModel/);
+  });
+
+  it("rejects openAICompatible with a non-custom modelType", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAICompatible",
+        modelType: "gpt-4o",
+        customModel: "gpt-4o",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiKey: "key-123",
+      }),
+    ).toThrow(/custom-model/);
+  });
+
+  it("rejects openAICompatible-only fields on other providers", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAI",
+        modelType: "gpt-4o",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiKey: "sk-abc123",
+      }),
+    ).toThrow(/openAICompatible/);
+  });
+
+  it("rejects apiType for providers without Responses API support", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "anthropic",
+        modelType: "claude-sonnet-4-0",
+        apiType: "responses",
+        apiKey: "key-123",
+      }),
+    ).toThrow(/apiType/);
+  });
+
+  it("rejects an invalid apiType value", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        customModel: "llama-3.3-70b-instruct",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiType: "completions",
+        apiKey: "key-123",
+      }),
+    ).toThrow();
+  });
 });
 
 describe("talkToAgentSchema", () => {

--- a/src/__tests__/schemas.test.ts
+++ b/src/__tests__/schemas.test.ts
@@ -246,6 +246,20 @@ describe("setupLlmSchema", () => {
     expect(result.modelType).toBe("custom-embedding-model");
   });
 
+  it("rejects apiType for openAICompatible embedding models", () => {
+    expect(() =>
+      schemas.setupLlmSchema.parse({
+        projectId: VALID_ID,
+        provider: "openAICompatible",
+        modelType: "custom-embedding-model",
+        customModel: "bge-large-en-v1.5",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiType: "responses",
+        apiKey: "key-123",
+      }),
+    ).toThrow(/apiType is only supported for chat models/);
+  });
+
   it("rejects openAICompatible without baseCustomUrl", () => {
     expect(() =>
       schemas.setupLlmSchema.parse({

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -410,6 +410,39 @@ describe("ToolHandlers v2", () => {
       );
     });
 
+    it("uses unique names for auto-created connections", async () => {
+      api.post
+        .mockResolvedValueOnce({
+          _id: "conn1",
+          referenceId: "conn-ref-uuid-1",
+        })
+        .mockResolvedValueOnce(mockLlm)
+        .mockResolvedValueOnce(mockTestSuccess)
+        .mockResolvedValueOnce({
+          _id: "conn2",
+          referenceId: "conn-ref-uuid-2",
+        })
+        .mockResolvedValueOnce(mockLlm)
+        .mockResolvedValueOnce(mockTestSuccess);
+
+      const args = {
+        projectId: ID.project,
+        provider: "openAI",
+        modelType: "gpt-4o",
+        apiKey: "sk-test",
+      };
+      await h.handleToolCall("setup_llm", args);
+      await h.handleToolCall("setup_llm", args);
+
+      const connectionNames = api.post.mock.calls
+        .filter((call: any[]) => call[0] === "/v2.0/connections")
+        .map((call: any[]) => call[1].name);
+      expect(connectionNames).toHaveLength(2);
+      expect(connectionNames[0]).toMatch(/^openAI - auto - /);
+      expect(connectionNames[1]).toMatch(/^openAI - auto - /);
+      expect(connectionNames[0]).not.toBe(connectionNames[1]);
+    });
+
     it("creates LLM directly when connectionId provided", async () => {
       const llmWithExistingConn = {
         ...mockLlm,

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -553,6 +553,101 @@ describe("ToolHandlers v2", () => {
       expect(result.error).toContain("was not found in the target project");
       expect(api.post).not.toHaveBeenCalled();
     });
+
+    it("creates an openAICompatible LLM with provider metadata and connection type", async () => {
+      const mockCompatLlm = {
+        _id: ID.llm,
+        referenceId: "llm-ref-uuid",
+        name: "llama-3.3-70b-instruct",
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        connectionId: "conn-ref-uuid",
+        isDefault: true,
+        apiType: "chatCompletion",
+        openAICompatible: {
+          customModel: "llama-3.3-70b-instruct",
+          baseCustomUrl: "https://llm.example.com/v1",
+          customAuthHeader: "X-Custom-Auth",
+        },
+      };
+      const mockConn = { _id: "conn1", referenceId: "conn-ref-uuid" };
+      api.post
+        .mockResolvedValueOnce(mockConn)
+        .mockResolvedValueOnce(mockCompatLlm)
+        .mockResolvedValueOnce(mockTestSuccess);
+
+      const result = await h.handleToolCall("setup_llm", {
+        projectId: ID.project,
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        customModel: "llama-3.3-70b-instruct",
+        baseCustomUrl: "https://llm.example.com/v1",
+        customAuthHeader: "X-Custom-Auth",
+        apiType: "chatCompletion",
+        apiKey: "key-123",
+      });
+
+      expect(api.post).toHaveBeenCalledWith(
+        "/v2.0/connections",
+        expect.objectContaining({
+          type: "OpenAICompatibleProvider",
+          extension: "@cognigy/generative-ai-provider",
+          fields: { apiKey: "key-123" },
+        }),
+      );
+      expect(api.post).toHaveBeenCalledWith(
+        "/v2.0/largelanguagemodels",
+        expect.objectContaining({
+          // Falls back to customModel, not the generic "custom-model" string
+          name: "llama-3.3-70b-instruct",
+          modelType: "custom-model",
+          provider: "openAICompatible",
+          apiType: "chatCompletion",
+          openAICompatible: {
+            customModel: "llama-3.3-70b-instruct",
+            baseCustomUrl: "https://llm.example.com/v1",
+            customAuthHeader: "X-Custom-Auth",
+          },
+        }),
+      );
+      expect(result.provider).toBe("openAICompatible");
+      expect(result.openAICompatible).toEqual({
+        customModel: "llama-3.3-70b-instruct",
+        baseCustomUrl: "https://llm.example.com/v1",
+        customAuthHeader: "X-Custom-Auth",
+      });
+      expect(result.apiType).toBe("chatCompletion");
+    });
+
+    it("omits customAuthHeader and apiType from the payload when not provided", async () => {
+      const mockConn = { _id: "conn1", referenceId: "conn-ref-uuid" };
+      api.post
+        .mockResolvedValueOnce(mockConn)
+        .mockResolvedValueOnce({
+          ...mockLlm,
+          provider: "openAICompatible",
+          modelType: "custom-model",
+        })
+        .mockResolvedValueOnce(mockTestSuccess);
+
+      await h.handleToolCall("setup_llm", {
+        projectId: ID.project,
+        provider: "openAICompatible",
+        modelType: "custom-model",
+        customModel: "llama-3.3-70b-instruct",
+        baseCustomUrl: "https://llm.example.com/v1",
+        apiKey: "key-123",
+      });
+
+      const llmPayload = api.post.mock.calls.find(
+        (call: any[]) => call[0] === "/v2.0/largelanguagemodels",
+      )?.[1];
+      expect(llmPayload.openAICompatible).toEqual({
+        customModel: "llama-3.3-70b-instruct",
+        baseCustomUrl: "https://llm.example.com/v1",
+      });
+      expect(llmPayload).not.toHaveProperty("apiType");
+    });
   });
 
   // =========================================================================

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -34,16 +34,85 @@ export const updateAiAgentSchema = z.object({
 });
 
 // Tool 3: setup_llm
-export const setupLlmSchema = z.object({
-  projectId: idSchema,
-  provider: z.enum(["openAI", "azureOpenAI", "anthropic", "google", "mistral"]),
-  modelType: z.string().min(1),
-  name: z.string().optional(),
-  apiKey: z.string().optional(),
-  connectionId: z.string().optional(),
-  isDefault: z.boolean().optional(),
-  dangerouslySkipConnectionTest: z.boolean().optional(),
-});
+export const setupLlmSchema = z
+  .object({
+    projectId: idSchema,
+    provider: z.enum([
+      "openAI",
+      "azureOpenAI",
+      "anthropic",
+      "google",
+      "mistral",
+      "openAICompatible",
+    ]),
+    modelType: z.string().min(1),
+    name: z.string().optional(),
+    apiKey: z.string().optional(),
+    connectionId: z.string().optional(),
+    isDefault: z.boolean().optional(),
+    baseCustomUrl: z.string().url().optional(),
+    customModel: z.string().min(1).optional(),
+    customAuthHeader: z.string().min(1).optional(),
+    apiType: z.enum(["chatCompletion", "responses"]).optional(),
+    dangerouslySkipConnectionTest: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (data.provider === "openAICompatible") {
+      if (!data.baseCustomUrl) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["baseCustomUrl"],
+          message:
+            "Provider 'openAICompatible' requires baseCustomUrl — the provider's OpenAI-compatible API base URL (e.g. https://my-llm-host.example.com/v1).",
+        });
+      }
+      if (!data.customModel) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["customModel"],
+          message:
+            "Provider 'openAICompatible' requires customModel — the model name as known by the provider (e.g. 'llama-3.3-70b-instruct').",
+        });
+      }
+      if (
+        data.modelType !== "custom-model" &&
+        data.modelType !== "custom-embedding-model"
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["modelType"],
+          message:
+            "Provider 'openAICompatible' requires modelType 'custom-model' (chat) or 'custom-embedding-model' (embedding). Put the provider's model name in customModel instead.",
+        });
+      }
+    } else {
+      for (const field of [
+        "baseCustomUrl",
+        "customModel",
+        "customAuthHeader",
+      ] as const) {
+        if (data[field] !== undefined) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: [field],
+            message: `${field} is only supported for provider 'openAICompatible'.`,
+          });
+        }
+      }
+      if (
+        data.apiType !== undefined &&
+        data.provider !== "openAI" &&
+        data.provider !== "azureOpenAI"
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["apiType"],
+          message:
+            "apiType is only supported for providers 'openAI', 'azureOpenAI', and 'openAICompatible'.",
+        });
+      }
+    }
+  });
 
 // Tool 4: talk_to_agent
 export const talkToAgentSchema = z

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -85,6 +85,17 @@ export const setupLlmSchema = z
             "Provider 'openAICompatible' requires modelType 'custom-model' (chat) or 'custom-embedding-model' (embedding). Put the provider's model name in customModel instead.",
         });
       }
+      if (
+        data.modelType === "custom-embedding-model" &&
+        data.apiType !== undefined
+      ) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ["apiType"],
+          message:
+            "apiType is only supported for chat models; omit it when modelType is 'custom-embedding-model'.",
+        });
+      }
     } else {
       for (const field of [
         "baseCustomUrl",

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -159,7 +159,7 @@ export const tools: ToolDefinition[] = [
         name: {
           type: "string",
           description:
-            "Display name for the LLM resource (defaults to modelType if omitted)",
+            "Display name for the LLM resource. If omitted, defaults to customModel for openAICompatible providers and modelType for all other providers.",
         },
         apiKey: {
           type: "string",

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -126,7 +126,7 @@ export const tools: ToolDefinition[] = [
   {
     name: "setup_llm",
     description:
-      "Create a NEW LLM resource (GPT-4, Claude, etc.) in a project. This is a LAST RESORT — only use when no existing LLM can be reused.\n\nPRECONDITION — you MUST have already completed ALL of these before calling this tool:\n1. Listed all projects: list_resources { resourceType: 'project' }\n2. Checked every other project for existing LLMs: list_resources { resourceType: 'llm_model', projectId }\n3. Attempted package reuse where another project already has a reusable LLM with connectionId\n4. Proceeding only because reuse is unavailable, transfer failed, or the user explicitly asked for a brand-new LLM\nIf you have not completed steps 1-4, STOP and do them first. Do NOT call this tool.\n\nMODEL ROLE WARNING:\n- Chat/completion models are used for AI Agents.\n- Embedding models are used for knowledge-store indexing.\n- Knowledge Search and Answer Extraction use same-project llm_model IDs accepted by the Cognigy API for that use case.\n- Do not use setup_llm as an automatic workaround for knowledgeSearchModelId failures while existing same-project candidates still exist.\n\nIMPORTANT: NEVER guess or hallucinate API keys. If creating a new LLM and no apiKey or connectionId was provided by the user, ASK for the required credentials.\n\nAfter creation, the connection is normally tested by sending a minimal probe to the provider. If this connection test runs and fails (for example, invalid credentials or model name), the model is deleted and an error is returned — this prevents broken model references from silently breaking downstream flows.\n\nIf the provider's test endpoint is unreachable or returns a non-testable status, the model is kept but a warning is returned so you know connectivity could not be fully verified.\n\nIf dangerouslySkipConnectionTest is true, the connection test is not run at all; the model is kept and the response includes a warning that no connectivity check was performed. Only use this flag when you explicitly accept the risk that the created LLM might not be callable. Never use it to bypass a missing or cross-project connection.\n\nIf isDefault is true (the default), agents in the project will automatically use this LLM. If isDefault is false, you must explicitly assign it to the agent via update_ai_agent { aiAgentId, jobConfig: { llmProviderReferenceId: '<referenceId from this response>' } }.\n\nThe response includes the LLM's referenceId — use this value for jobConfig.llmProviderReferenceId if assigning manually.\n\nTo list existing LLMs: use list_resources { resourceType: 'llm_model', projectId }.\nTo delete: use delete_resource { resourceType: 'llm_model', id }.",
+      "Create a NEW LLM resource (GPT-4, Claude, etc.) in a project. This is a LAST RESORT — only use when no existing LLM can be reused.\n\nPRECONDITION — you MUST have already completed ALL of these before calling this tool:\n1. Listed all projects: list_resources { resourceType: 'project' }\n2. Checked every other project for existing LLMs: list_resources { resourceType: 'llm_model', projectId }\n3. Attempted package reuse where another project already has a reusable LLM with connectionId\n4. Proceeding only because reuse is unavailable, transfer failed, or the user explicitly asked for a brand-new LLM\nIf you have not completed steps 1-4, STOP and do them first. Do NOT call this tool.\n\nMODEL ROLE WARNING:\n- Chat/completion models are used for AI Agents.\n- Embedding models are used for knowledge-store indexing.\n- Knowledge Search and Answer Extraction use same-project llm_model IDs accepted by the Cognigy API for that use case.\n- Do not use setup_llm as an automatic workaround for knowledgeSearchModelId failures while existing same-project candidates still exist.\n\nOPENAI-COMPATIBLE PROVIDERS (self-hosted or third-party endpoints that speak the OpenAI API, e.g. vLLM, Hugging Face, LiteLLM, Azure AI Foundry): use provider 'openAICompatible' with modelType 'custom-model' (chat) or 'custom-embedding-model' (embedding). The actual model name goes in customModel and the endpoint in baseCustomUrl — both required. Optional: customAuthHeader (send the API key in a custom header instead of 'Authorization: Bearer'), apiType ('chatCompletion' default, or 'responses').\n\nIMPORTANT: NEVER guess or hallucinate API keys. If creating a new LLM and no apiKey or connectionId was provided by the user, ASK for the required credentials.\n\nAfter creation, the connection is normally tested by sending a minimal probe to the provider. If this connection test runs and fails (for example, invalid credentials or model name), the model is deleted and an error is returned — this prevents broken model references from silently breaking downstream flows.\n\nIf the provider's test endpoint is unreachable or returns a non-testable status, the model is kept but a warning is returned so you know connectivity could not be fully verified.\n\nIf dangerouslySkipConnectionTest is true, the connection test is not run at all; the model is kept and the response includes a warning that no connectivity check was performed. Only use this flag when you explicitly accept the risk that the created LLM might not be callable. Never use it to bypass a missing or cross-project connection.\n\nIf isDefault is true (the default), agents in the project will automatically use this LLM. If isDefault is false, you must explicitly assign it to the agent via update_ai_agent { aiAgentId, jobConfig: { llmProviderReferenceId: '<referenceId from this response>' } }.\n\nThe response includes the LLM's referenceId — use this value for jobConfig.llmProviderReferenceId if assigning manually.\n\nTo list existing LLMs: use list_resources { resourceType: 'llm_model', projectId }.\nTo delete: use delete_resource { resourceType: 'llm_model', id }.",
     annotations: {
       title: "Setup LLM",
       readOnlyHint: false,
@@ -140,14 +140,21 @@ export const tools: ToolDefinition[] = [
         projectId: { type: "string", description: "24-char hex project ID" },
         provider: {
           type: "string",
-          enum: ["openAI", "azureOpenAI", "anthropic", "google", "mistral"],
+          enum: [
+            "openAI",
+            "azureOpenAI",
+            "anthropic",
+            "google",
+            "mistral",
+            "openAICompatible",
+          ],
           description:
-            "LLM provider (API values: 'openAI', 'azureOpenAI', 'anthropic', 'google', 'mistral').",
+            "LLM provider (API values: 'openAI', 'azureOpenAI', 'anthropic', 'google', 'mistral', 'openAICompatible'). Use 'openAICompatible' for any endpoint that speaks the OpenAI API (vLLM, Hugging Face, LiteLLM, Azure AI Foundry, ...).",
         },
         modelType: {
           type: "string",
           description:
-            "Model type string. Chat examples: 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-0', 'mistral-small-2503'. Embedding examples: 'text-embedding-3-small', 'text-embedding-3-large', 'text-embedding-ada-002', 'gemini-embedding-001'.",
+            "Model type string. Chat examples: 'gpt-4o', 'gpt-4o-mini', 'claude-sonnet-4-0', 'mistral-small-2503'. Embedding examples: 'text-embedding-3-small', 'text-embedding-3-large', 'text-embedding-ada-002', 'gemini-embedding-001'. For provider 'openAICompatible' this MUST be 'custom-model' (chat) or 'custom-embedding-model' (embedding); the real model name goes in customModel.",
         },
         name: {
           type: "string",
@@ -167,6 +174,27 @@ export const tools: ToolDefinition[] = [
         isDefault: {
           type: "boolean",
           description: "Set as project default (default: true)",
+        },
+        baseCustomUrl: {
+          type: "string",
+          description:
+            "openAICompatible only (required): base URL of the OpenAI-compatible API, e.g. 'https://my-llm-host.example.com/v1'.",
+        },
+        customModel: {
+          type: "string",
+          description:
+            "openAICompatible only (required): the model name as known by the provider, e.g. 'llama-3.3-70b-instruct'.",
+        },
+        customAuthHeader: {
+          type: "string",
+          description:
+            "openAICompatible only (optional): custom HTTP header name for authentication, e.g. 'X-Custom-Auth' or 'Ocp-Apim-Subscription-Key'. When set, the API key is sent in this header instead of 'Authorization: Bearer'.",
+        },
+        apiType: {
+          type: "string",
+          enum: ["chatCompletion", "responses"],
+          description:
+            "API flavor for chat models (openAI, azureOpenAI, openAICompatible only). Default: 'chatCompletion'. Use 'responses' only if the provider supports OpenAI's Responses API.",
         },
         dangerouslySkipConnectionTest: {
           type: "boolean",

--- a/src/tools/filters.ts
+++ b/src/tools/filters.ts
@@ -70,6 +70,8 @@ export const RESOURCE_FILTERS: Record<string, (raw: any) => any> = {
     modelType: r.modelType,
     connectionId: r.connectionId,
     isDefault: r.isDefault,
+    apiType: r.apiType,
+    openAICompatible: r.openAICompatible,
   }),
   knowledge_store: (r) => ({
     id: rid(r),

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -477,6 +477,7 @@ const PROVIDER_CONNECTION_TYPE: Record<string, string> = {
   anthropic: "AnthropicProvider",
   google: "GoogleVertexAIProvider",
   mistral: "MistralProvider",
+  openAICompatible: "OpenAICompatibleProvider",
 };
 
 /**
@@ -1734,7 +1735,20 @@ export class ToolHandlers {
       }
     }
 
-    const displayName = data.name || data.modelType;
+    const displayName = data.name || data.customModel || data.modelType;
+
+    // Provider-specific metadata. For openAICompatible the actual model name
+    // and endpoint live here — modelType is just "custom-model" / "custom-embedding-model".
+    const providerMeta =
+      data.provider === "openAICompatible"
+        ? {
+            customModel: data.customModel,
+            baseCustomUrl: data.baseCustomUrl,
+            ...(data.customAuthHeader
+              ? { customAuthHeader: data.customAuthHeader }
+              : {}),
+          }
+        : {};
 
     let result: any;
     try {
@@ -1745,7 +1759,8 @@ export class ToolHandlers {
         provider: data.provider,
         connectionId: connectionRefId,
         isDefault: data.isDefault ?? true,
-        [data.provider]: {},
+        ...(data.apiType ? { apiType: data.apiType } : {}),
+        [data.provider]: providerMeta,
       });
     } catch (error: any) {
       return withHints(

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -1718,7 +1718,7 @@ export class ToolHandlers {
       try {
         const connection: any = await this.apiClient.post("/v2.0/connections", {
           projectId: data.projectId,
-          name: `${data.provider} - auto`,
+          name: `${data.provider} - auto - ${randomUUID()}`,
           type: PROVIDER_CONNECTION_TYPE[data.provider] ?? data.provider,
           extension: "@cognigy/generative-ai-provider",
           fields: { apiKey: data.apiKey },


### PR DESCRIPTION
## Summary

- Add `openAICompatible` provider support to `setup_llm` — any endpoint that speaks the OpenAI API (vLLM, Hugging Face, LiteLLM, Azure AI Foundry, self-hosted) can now be configured, closing the gap reported by users who couldn't set up OpenAI-compatible LLMs through the plugin
- Add the required provider metadata plumbing: `baseCustomUrl`, `customModel`, `customAuthHeader`, and `apiType` (`chatCompletion` | `responses`) flow into the `openAICompatible` metadata object of `POST /v2.0/largelanguagemodels` (previously the handler always sent an empty metadata object, so a base URL could never be expressed)
- Expose `apiType` and the `openAICompatible` metadata in `llm_model` responses so existing OpenAI-compatible models can be inspected and reused (previously filtered out, hiding the base URL and real model name)
- Document the workflow in the `llm-providers` skill, including the `custom-model` modelType gotcha and the deprecated Completions API

## Changes

| File / Component                       | Description                                                                                                                                                                              |
| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `src/schemas/tools.ts`                 | `setupLlmSchema` gains the `openAICompatible` provider and new optional fields; `superRefine` enforces `baseCustomUrl` + `customModel` + custom modelType for it and rejects the fields on other providers, with actionable error messages |
| `src/tools/handlers.ts`                | Map `openAICompatible` → `OpenAICompatibleProvider` connection type; build the provider metadata object and pass `apiType` through; display name falls back to `customModel` instead of the generic `custom-model` string |
| `src/tools/definitions.ts`             | `setup_llm` inputSchema and description updated with the new provider, parameters, and an OPENAI-COMPATIBLE usage section                                                                  |
| `src/tools/filters.ts`                 | `llm_model` filter now returns `apiType` and `openAICompatible` metadata                                                                                                                   |
| `plugin/skills/llm-providers/SKILL.md` | New provider table row and a dedicated OpenAI-compatible section (required params, examples, gotchas)                                                                                     |
| `src/__tests__/*`                      | Schema and handler tests for the new provider (payload shape, connection type, validation errors)                                                                                         |

The `OpenAICompatibleProvider` connection type, `openAICompatible` metadata shape, and allowed model types (`custom-model` / `custom-embedding-model`) were verified against the Cognigy.AI source and a live openAICompatible model.

## Follow-up

The Cognigy API also supports `awsBedrock` and `googleGenAI` providers, which the plugin should support as well (deliberately out of scope here; `googleGemini` is superseded by `googleGenAI`, and `alephAlpha` is effectively dead).

## Test plan

Automated — CI runs tests and Prettier checks on every PR via `.github/workflows/pr.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)