### PR TITLE
fix: make credentials work on hosts without userConfig support (VS Code, Cursor)

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,16 @@ The plugin ships its own connector (`platform`), but on **Claude Desktop chat** 
 
 > 🔄 **Claude Desktop users:** the connector keeps its engine current on every restart, but see [Staying up to date](#staying-up-to-date) for how updates work and how to check versions.
 
+### Step 3 — Other hosts (VS Code, Cursor, …): install the plugin yourself
+
+Pick **Other hosts** in the installer (or pass `--client other-hosts`) and it writes your credentials to `~/.cognigy-plugin/config.json` (`chmod 600`). Nothing else is wired — these hosts install the plugin themselves:
+
+**VS Code / Copilot** — in `settings.json`, set `"chat.plugins.enabled": true` and add `"chat.plugins.marketplaces": ["Cognigy/cognigy-plugin"]`, then open the Extensions view, search `@agentPlugins`, and install **cognigy**. Restart afterwards. You get tools, skills, and agents.
+
+**Leave the plugin's credential fields alone.** Only Claude Code implements `userConfig`, the manifest extension that prompts for an API key and substitutes it into the server's environment. Every other host copies the manifest text through verbatim, so the engine would receive the literal `${user_config.cognigy_api_key}`. It treats such placeholders as unset and reads the file above instead — which is why the installer writes it.
+
+> **`npx: command not found` when the server starts?** Your Node is probably from nvm/fnm/volta, whose bin directory a GUI-launched host may not have on `PATH`. Quit the host completely and relaunch it from a terminal, or point the MCP entry at an absolute path (`$(which npx)`).
+
 <details>
 <summary>Scripting / CI, and manual install</summary>
 
@@ -113,6 +123,8 @@ npx -y -p @cognigy/plugin-engine@latest cognigy-setup \
   --client claude-code --client claude-desktop \
   --api-base-url https://api-trial.cognigy.ai --api-key <key>
 ```
+
+`--client` is repeatable; valid values are `claude-code`, `claude-desktop`, and `other-hosts`. Omit it in interactive mode to pick from the menu.
 
 **Manual install (Claude Code)** — instead of the installer:
 
@@ -156,7 +168,9 @@ Create a complete AI Agent in one tool call, then iterate and improve through co
 
 ## Configuration
 
-The [installer](#installation) collects your **Cognigy API base URL** and **API key** and wires them per client: on Claude Code into the system **keychain**, on Claude Desktop into `claude_desktop_config.json` (`chmod 600`). The engine receives them as environment variables. If neither is set for a given launch, the engine falls back to `~/.cognigy-plugin/config.json` (`chmod 600`), which the installer also writes — so credentials resolve from the environment first, then that file. The optional variables below can be set in the MCP server `env` if you need to override defaults.
+The [installer](#installation) collects your **Cognigy API base URL** and **API key** and wires them per client: on Claude Code into the system **keychain**, on Claude Desktop into `claude_desktop_config.json` (`chmod 600`). The engine receives them as environment variables. If either is missing for a given launch, the engine falls back to `~/.cognigy-plugin/config.json` (`chmod 600`), which the installer also writes — so credentials resolve from the environment first, then that file.
+
+A value that arrives as an unexpanded `${...}` placeholder counts as missing. Hosts other than Claude Code don't implement `userConfig` and pass the manifest's `${user_config.cognigy_api_key}` through literally; treating that as a real credential would both fail the request and shadow the file fallback. The optional variables below can be set in the MCP server `env` if you need to override defaults.
 
 | Variable                  | Required | Default | Description                      |
 | ------------------------- | -------- | ------- | -------------------------------- |

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -205,4 +205,57 @@ describe("loadConfig", () => {
       expect(() => loadConfig()).toThrow(/setup/);
     });
   });
+
+  // Hosts that don't implement the `userConfig` manifest extension (VS Code,
+  // Cursor, …) pass "${user_config.cognigy_api_key}" through verbatim. Those
+  // strings are non-empty, so without this handling they both masquerade as
+  // real credentials and shadow the on-disk fallback.
+  describe("unexpanded userConfig placeholders", () => {
+    const BASE_PLACEHOLDER = "${user_config.cognigy_api_base_url}";
+    const KEY_PLACEHOLDER = "${user_config.cognigy_api_key}";
+
+    it("treats placeholder env values as unset and reads the file instead", () => {
+      process.env.COGNIGY_API_BASE_URL = BASE_PLACEHOLDER;
+      process.env.COGNIGY_API_KEY = KEY_PLACEHOLDER;
+      readUserConfigFile.mockReturnValue({
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+        COGNIGY_API_KEY: "file-key",
+      });
+      const config = loadConfig();
+      expect(config.apiBaseUrl).toBe("https://api-trial.cognigy.ai");
+      expect(config.apiKey).toBe("file-key");
+    });
+
+    it("does not use a placeholder as the API base URL", () => {
+      process.env.COGNIGY_API_BASE_URL = BASE_PLACEHOLDER;
+      process.env.COGNIGY_API_KEY = "real-key";
+      readUserConfigFile.mockReturnValue({
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+      });
+      // Previously the placeholder survived normalisation and reached axios as
+      // a baseURL, producing ERR_INVALID_URL on the first request.
+      expect(loadConfig().apiBaseUrl).toBe("https://api-trial.cognigy.ai");
+    });
+
+    it("explains the placeholder in the error when no fallback exists", () => {
+      process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+      process.env.COGNIGY_API_KEY = KEY_PLACEHOLDER;
+      expect(() => loadConfig()).toThrow(/did not substitute/);
+    });
+
+    it("tolerates surrounding whitespace around a placeholder", () => {
+      process.env.COGNIGY_API_BASE_URL = `  ${BASE_PLACEHOLDER}  `;
+      process.env.COGNIGY_API_KEY = "real-key";
+      readUserConfigFile.mockReturnValue({
+        COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+      });
+      expect(loadConfig().apiBaseUrl).toBe("https://api-trial.cognigy.ai");
+    });
+
+    it("keeps real values that merely contain a dollar sign", () => {
+      process.env.COGNIGY_API_BASE_URL = "https://api-trial.cognigy.ai";
+      process.env.COGNIGY_API_KEY = "ab$c{def}";
+      expect(loadConfig().apiKey).toBe("ab$c{def}");
+    });
+  });
 });

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -33,6 +33,7 @@ import {
   writeDesktopLauncher,
 } from "../install/desktopLauncher.js";
 import {
+  detectClients,
   isMainModule,
   parseClientSelection,
   parseFlags,
@@ -349,6 +350,20 @@ describe("parseFlags", () => {
 
   it("ignores unknown --client values", () => {
     expect(parseFlags(["--client", "codex"]).clients).toEqual([]);
+  });
+
+  it("accepts the other-hosts target", () => {
+    expect(parseFlags(["--client=other-hosts"]).clients).toEqual([
+      "other-hosts",
+    ]);
+  });
+});
+
+describe("detectClients", () => {
+  // Writing a plaintext API key to disk is opt-in: 'other-hosts' must never be
+  // auto-detected, because detected clients become the pre-checked defaults.
+  it("never pre-selects other-hosts", () => {
+    expect(detectClients()["other-hosts"]).toBe(false);
   });
 });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -109,6 +109,44 @@ function deriveWebchatBaseUrl(apiBaseUrl: string): string {
   return apiBaseUrl.replace(/\/api-/, "/webchat-");
 }
 
+/**
+ * True for a value that is nothing but an unexpanded `${...}` placeholder.
+ *
+ * `userConfig` is a Claude Code extension to the plugin manifest: Claude Code
+ * prompts for the values and substitutes them into `mcpServers.*.env`. Hosts
+ * that only implement the portable subset (VS Code / Copilot, Cursor, …) copy
+ * the manifest text through verbatim, so the engine receives the literal
+ * "${user_config.cognigy_api_key}". Those strings are non-empty, which means
+ * that without this check they (a) reach axios as a real base URL and fail with
+ * ERR_INVALID_URL, and (b) shadow the on-disk fallback written by the setup CLI.
+ *
+ * Deliberately anchored to the whole (trimmed) value: a real API key or URL is
+ * never entirely wrapped in `${…}`, so this cannot discard a genuine credential.
+ */
+function isUnexpandedPlaceholder(value: string): boolean {
+  const trimmed = value.trim();
+  return trimmed.startsWith("${") && trimmed.endsWith("}");
+}
+
+/** An env value, or undefined when absent or an unexpanded placeholder. */
+function usableEnv(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  return isUnexpandedPlaceholder(value) ? undefined : value;
+}
+
+/**
+ * Extra sentence for the "not set" errors when the host handed us a
+ * placeholder. Without it the message reads as "not set" to someone looking
+ * straight at a manifest that plainly does set it.
+ */
+function placeholderHint(raw: string | undefined): string {
+  if (!raw || !isUnexpandedPlaceholder(raw)) return "";
+  return (
+    ` This host did not substitute the plugin manifest placeholder ${raw.trim()} ` +
+    `(it does not support userConfig), so the value never arrived.`
+  );
+}
+
 const VALID_LOG_LEVELS = new Set<string>(["debug", "info", "warn", "error"]);
 
 function parseIntWithDefault(
@@ -131,28 +169,32 @@ function parseIntWithDefault(
  */
 export function loadConfig(): Config {
   // Environment variables win (terminal install stores them via userConfig /
-  // keychain). Only when one is missing do we consult the on-disk fallback
-  // written by the `cognigy-setup` CLI — this is the path GUI users take
-  // when their installer never prompted for credentials.
-  const fileConfig =
-    process.env.COGNIGY_API_BASE_URL && process.env.COGNIGY_API_KEY
-      ? {}
-      : readUserConfigFile();
+  // keychain). Only when one is missing — or arrived as an unexpanded
+  // `${user_config.*}` placeholder, which is the same thing — do we consult the
+  // on-disk fallback written by the `cognigy-setup` CLI. That is the path hosts
+  // take when their installer never prompted for credentials.
+  const envApiBaseUrl = usableEnv(process.env.COGNIGY_API_BASE_URL);
+  const envApiKey = usableEnv(process.env.COGNIGY_API_KEY);
 
-  const apiBaseUrl =
-    process.env.COGNIGY_API_BASE_URL || fileConfig.COGNIGY_API_BASE_URL;
-  const apiKey = process.env.COGNIGY_API_KEY || fileConfig.COGNIGY_API_KEY;
+  const fileConfig = envApiBaseUrl && envApiKey ? {} : readUserConfigFile();
+
+  const apiBaseUrl = envApiBaseUrl || fileConfig.COGNIGY_API_BASE_URL;
+  const apiKey = envApiKey || fileConfig.COGNIGY_API_KEY;
 
   if (!apiBaseUrl) {
     throw new Error(
-      `COGNIGY_API_BASE_URL is not set. Provide it via the plugin install prompt, ` +
+      `COGNIGY_API_BASE_URL is not set.` +
+        placeholderHint(process.env.COGNIGY_API_BASE_URL) +
+        ` Provide it via the plugin install prompt, ` +
         `or run "npx -y -p @cognigy/plugin-engine cognigy-setup" to write ${USER_CONFIG_FILE}.`,
     );
   }
 
   if (!apiKey) {
     throw new Error(
-      `COGNIGY_API_KEY is not set. Provide it via the plugin install prompt, ` +
+      `COGNIGY_API_KEY is not set.` +
+        placeholderHint(process.env.COGNIGY_API_KEY) +
+        ` Provide it via the plugin install prompt, ` +
         `or run "npx -y -p @cognigy/plugin-engine cognigy-setup" to write ${USER_CONFIG_FILE}.`,
     );
   }

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -314,15 +314,16 @@ function runInstall(client: Client, creds: UserConfigFile): void {
             "  VS Code has no prompt for them; this file covers it.\n",
         ),
     );
-    // The manifest's `npx` is resolved from PATH. A GUI-launched app (Dock,
-    // Spotlight) does not source the user's shell profile, so a node installed
-    // via nvm/fnm/volta is invisible to it and the server dies with
-    // "npx: command not found". Launching from a terminal inherits PATH.
+    // The manifest's `npx` is resolved from PATH, and some hosts have been seen
+    // to start it with a PATH that excludes a node installed via nvm/fnm/volta
+    // (their bin dir is added by the shell profile, which a GUI-launched app
+    // need not have sourced). Not reproducible on demand — printed as
+    // conditional troubleshooting, not as a known defect.
     process.stdout.write(
       "\n" +
         yellow(bold("  If the server fails with 'npx: command not found':")) +
         "\n" +
-        `    ${cyan("•")} Your node is likely from nvm/fnm/volta, which a GUI-launched app cannot see.\n` +
+        `    ${cyan("•")} Your node is probably from nvm/fnm/volta, whose bin dir the host may not have on PATH.\n` +
         `    ${cyan("•")} Quit the host completely and relaunch it from a terminal, or\n` +
         `    ${cyan("•")} point the MCP entry at an absolute path (e.g. ${dim("$(which npx)")}).\n`,
     );

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -16,6 +16,7 @@
 import { createInterface } from "readline";
 import { pathToFileURL } from "url";
 import type { UserConfigFile } from "./userConfigFile.js";
+import { writeUserConfigFile } from "./userConfigFile.js";
 import {
   autoUpdateHint,
   detectClaudePath,
@@ -58,14 +59,15 @@ const CTRL_D = 4;
 const BACKSPACE = 8;
 const DELETE = 127;
 
-type Client = "claude-code" | "claude-desktop";
-const ALL_CLIENTS: Client[] = ["claude-code", "claude-desktop"];
+type Client = "claude-code" | "claude-desktop" | "other-hosts";
+const ALL_CLIENTS: Client[] = ["claude-code", "claude-desktop", "other-hosts"];
 const CLIENT_LABELS: Record<Client, string> = {
   // Post-Apr-2026 Desktop redesign: the standalone CLI and Desktop's "Code" tab
   // share ~/.claude, so one Claude-Code install serves both. "Claude Desktop"
   // here means the separate Chat connector wired into claude_desktop_config.json.
   "claude-code": "Claude Code (CLI + Desktop 'Code' tab)",
   "claude-desktop": "Claude Desktop chat (standalone connector)",
+  "other-hosts": "Other hosts (VS Code, Cursor, …) — writes a local creds file",
 };
 
 interface Flags {
@@ -104,6 +106,10 @@ export function detectClients(): Record<Client, boolean> {
   return {
     "claude-code": detectClaudePath() !== null,
     "claude-desktop": existsSync(dirname(resolveDesktopConfigPath())),
+    // Never auto-detected, so it is never pre-checked: writing a plaintext key
+    // to disk must stay an explicit choice. Claude-only users keep the keychain
+    // path with nothing on disk.
+    "other-hosts": false,
   };
 }
 
@@ -286,6 +292,42 @@ async function chooseClients(): Promise<Client[]> {
 }
 
 function runInstall(client: Client, creds: UserConfigFile): void {
+  if (client === "other-hosts") {
+    // Nothing to wire: these hosts either install the plugin themselves (VS
+    // Code reads our Claude-format manifest) or take a hand-written MCP entry.
+    // What they cannot do is supply credentials — `userConfig` is Claude-only,
+    // so they pass "${user_config.*}" through untouched. The engine treats such
+    // placeholders as unset and falls back to this file.
+    const configFile = writeUserConfigFile(creds);
+    process.stdout.write(
+      green("\n✓ Other hosts") +
+        `: wrote credentials to ${configFile} ` +
+        dim("(dir 0700, file 0600)") +
+        ".\n" +
+        "  Any host that starts the engine now picks these up automatically.\n\n" +
+        `  ${bold("VS Code / Copilot")} — install the plugin, then restart:\n` +
+        `      ${cyan("1.")} Set ${bold('"chat.plugins.enabled": true')} in settings.json.\n` +
+        `      ${cyan("2.")} Add ${bold('"chat.plugins.marketplaces": ["Cognigy/cognigy-plugin"]')}.\n` +
+        `      ${cyan("3.")} Extensions view → search ${bold("@agentPlugins")} → install ${bold("cognigy")}.\n` +
+        dim(
+          "  You get tools, skills, and agents. Leave the credential fields alone —\n" +
+            "  VS Code has no prompt for them; this file covers it.\n",
+        ),
+    );
+    // The manifest's `npx` is resolved from PATH. A GUI-launched app (Dock,
+    // Spotlight) does not source the user's shell profile, so a node installed
+    // via nvm/fnm/volta is invisible to it and the server dies with
+    // "npx: command not found". Launching from a terminal inherits PATH.
+    process.stdout.write(
+      "\n" +
+        yellow(bold("  If the server fails with 'npx: command not found':")) +
+        "\n" +
+        `    ${cyan("•")} Your node is likely from nvm/fnm/volta, which a GUI-launched app cannot see.\n` +
+        `    ${cyan("•")} Quit the host completely and relaunch it from a terminal, or\n` +
+        `    ${cyan("•")} point the MCP entry at an absolute path (e.g. ${dim("$(which npx)")}).\n`,
+    );
+    return;
+  }
   if (client === "claude-code") {
     const res = installClaudeCode(creds);
     if (res.method === "cli") {
@@ -567,7 +609,8 @@ async function main(): Promise<void> {
     apiBaseUrl = apiBaseUrl || DEFAULT_BASE_URL;
     if (clients.length === 0) {
       process.stderr.write(
-        "No client selected. Pass --client claude-code and/or --client claude-desktop.\n",
+        "No client selected. Pass one or more of: --client claude-code, " +
+          "--client claude-desktop, --client other-hosts.\n",
       );
       process.exit(1);
     }


### PR DESCRIPTION
## Why

Found while testing VS Code / Copilot for the [plugin compatibility matrix](https://cognigy.atlassian.net/wiki/spaces/Engineering/pages/2684289044/Plugin+compatibility).

VS Code 1.125 installs our plugin properly: the marketplace works, all 13 skills load, both agents load, and it even reads the `mcpServers` block **inside** `plugin.json` (its docs only describe a separate `.mcp.json`, so this was a pleasant surprise). The server process starts. Then every tool call fails:

```
{"error":"Invalid URL","code":"ERR_INVALID_URL"}
```

`userConfig` is a **Claude Code extension** to the manifest format. Claude Code prompts for the values and substitutes them into `mcpServers.*.env`. Hosts implementing only the portable subset — VS Code / Copilot, Cursor — copy that text through verbatim, so the engine receives the literal string `"${user_config.cognigy_api_key}"`.

Those placeholders are **non-empty**, which broke two things in `loadConfig()`:

1. `COGNIGY_API_BASE_URL` reached axios as a base URL of `${user_config.cognigy_api_base_url}` → `ERR_INVALID_URL`.
2. Worse: they satisfied the "are the env vars set?" check and **shadowed the on-disk fallback**, so credentials written by `cognigy-setup` were ignored even when they existed.

There is no way to fix this from the host side. VS Code's own `${input:...}` secret prompt applies only to servers a user writes in their own `mcp.json`; there is no mechanism to inject a value into a server a *plugin* declares. So the fix has to be ours.

## What changed

**1. `src/config.ts` — treat unexpanded placeholders as unset**

A value that is entirely an unexpanded `${...}` is now ignored, so it falls through to `~/.cognigy-plugin/config.json`. The match is anchored to the whole trimmed value — a real key or URL is never wholly wrapped in `${…}`, so a genuine credential can't be discarded. The "not set" errors now also say when a placeholder was the cause, which otherwise reads as nonsense to someone staring at a manifest that plainly sets the value.

**2. `src/setup.ts` — new `other-hosts` install target**

Fix 1 alone wasn't enough: nothing wrote the fallback file on the happy path. `installClaudeCode` only wrote it when the `claude` CLI was **missing** or the install **failed** — so anyone who installed successfully into Claude Code (i.e. most people) had no fallback at all.

I deliberately did **not** make it always write. That would put a plaintext API key on disk for every user, including Claude-only users who today get keychain storage and nothing on disk — a silent security downgrade nobody asked for. Instead there's a third target in the client picker, and it is **never auto-detected**, so it is never pre-checked. Opt-in only.

It also prints the `npx: command not found` guidance (see below).

## Result

Install the plugin in VS Code → run `npx cognigy-setup` and tick **Other hosts** → tools, skills, and agents all work. No VS-Code-specific code, and the same file fixes Cursor and every other host with this limitation.

## How to verify

**Automated:**

```bash
npm test -- --runInBand      # 431 pass, 0 fail
npx tsc -p tsconfig.json --noEmit
npm run lint                 # 17 errors before and after — all pre-existing
                             # parse errors (test files are in tsconfig.test.json)
```

**The actual bug, before and after.** The unit tests mock `readUserConfigFile`, so they never prove the real file is read. This does:

```bash
FAKE=$(mktemp -d); mkdir -p "$FAKE/.cognigy-plugin"
cat > "$FAKE/.cognigy-plugin/config.json" <<'JSON'
{ "COGNIGY_API_BASE_URL": "https://api-trial.cognigy.ai", "COGNIGY_API_KEY": "from-the-file" }
JSON
cat > "$FAKE/probe.ts" <<'TS'
import { loadConfig } from "./src/config.js";
console.log("apiBaseUrl:", loadConfig().apiBaseUrl);
TS

HOME="$FAKE" \
  COGNIGY_API_BASE_URL='${user_config.cognigy_api_base_url}' \
  COGNIGY_API_KEY='${user_config.cognigy_api_key}' \
  npx tsx "$FAKE/probe.ts"
```

- On `main`: `apiBaseUrl: ${user_config.cognigy_api_base_url}` ← the bug
- On this branch: `apiBaseUrl: https://api-trial.cognigy.ai`

**The installer** (temp `HOME` so it can't touch your real config):

```bash
FAKE=$(mktemp -d)
HOME="$FAKE" npx tsx src/setup.ts --client other-hosts \
  --api-base-url https://api-trial.cognigy.ai --api-key TEST-KEY --yes
ls -la "$FAKE/.cognigy-plugin/"   # expect: dir 0700, config.json 0600
```

**End to end in VS Code:**

1. `"chat.plugins.enabled": true` and `"chat.plugins.marketplaces": ["Cognigy/cognigy-plugin"]` in settings.json
2. Extensions view → `@agentPlugins` → install **cognigy**
3. `npx cognigy-setup`, tick **Other hosts**
4. Restart VS Code, start the `platform` server, ask it to list your projects

If the server fails to start with `npx: command not found`, see the unresolved item below.

## Unresolved: `npx` resolution, cause not isolated

The manifest uses `"command": "npx"`, resolved from PATH. During testing on macOS with node installed via nvm, we saw it **both** fail and succeed, and did not isolate why:

- ❌ A `cognigy-manual` server in VS Code's **user `mcp.json`** failed with `npx: command not found`. Switching to an absolute path (`~/.nvm/versions/node/v24.15.0/bin/npx`) fixed it.
- ✅ The **plugin's own `platform` server**, with `"command": "npx"` untouched, started fine and discovered all 16 tools.

Two candidate explanations, untested:

1. **Launch method** — a Dock/Spotlight-launched app doesn't source your shell profile, so nvm's bin dir is invisible; a terminal launch inherits it. The two observations may simply have been launched differently.
2. **Config source** — VS Code may resolve the shell environment for plugin-declared servers but not for ones in the user `mcp.json` (or the reverse).

I originally wrote this up as a general "GUI hosts can't see nvm" product gap affecting every host in the compatibility matrix. **That was overstated** — one failure isn't enough to support it, and the plugin server working contradicts it. Recording it here as an open question rather than a known bug.

Worth isolating separately, since it decides whether anything needs fixing at all. `nvm` is common enough that if the failure mode is real and launch-dependent, it's worth knowing; if VS Code resolves shell env reliably, there's nothing to do. This PR only adds conditional troubleshooting text to the installer output, shown when a user actually hits the error.

## Notes for review

- Precedence is unchanged: real env vars still win, the file is still only a fallback. Claude Code keeps using the keychain and never reads the file.
- The fallback file is `0600` in a `0700` dir (unchanged; `writeUserConfigFile` re-tightens both in case they pre-existed).
- Two commits, `fix:` + `feat:`, so semantic-release picks a minor bump. Per convention I have not touched either version field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
