### PR TITLE
fix(server): shut down on stdin close, not just SIGINT/SIGTERM

### DIFF
--- a/src/__tests__/rateLimiter.test.ts
+++ b/src/__tests__/rateLimiter.test.ts
@@ -2,10 +2,17 @@
  * Tests for rate limiter
  */
 
-import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals';
-import { RateLimiter } from '../utils/rateLimiter.js';
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import { RateLimiter } from "../utils/rateLimiter.js";
 
-describe('RateLimiter', () => {
+describe("RateLimiter", () => {
   let rateLimiter: RateLimiter;
 
   beforeEach(() => {
@@ -19,46 +26,56 @@ describe('RateLimiter', () => {
     rateLimiter.destroy();
   });
 
-  it('should allow requests within limit', () => {
-    expect(rateLimiter.check('test-key')).toBe(true);
-    expect(rateLimiter.check('test-key')).toBe(true);
-    expect(rateLimiter.check('test-key')).toBe(true);
+  it("should allow requests within limit", () => {
+    expect(rateLimiter.check("test-key")).toBe(true);
+    expect(rateLimiter.check("test-key")).toBe(true);
+    expect(rateLimiter.check("test-key")).toBe(true);
   });
 
-  it('should block requests exceeding limit', () => {
-    rateLimiter.check('test-key');
-    rateLimiter.check('test-key');
-    rateLimiter.check('test-key');
-    expect(rateLimiter.check('test-key')).toBe(false);
+  it("should block requests exceeding limit", () => {
+    rateLimiter.check("test-key");
+    rateLimiter.check("test-key");
+    rateLimiter.check("test-key");
+    expect(rateLimiter.check("test-key")).toBe(false);
   });
 
-  it('should track remaining requests', () => {
-    expect(rateLimiter.getRemaining('test-key')).toBe(3);
-    rateLimiter.check('test-key');
-    expect(rateLimiter.getRemaining('test-key')).toBe(2);
-    rateLimiter.check('test-key');
-    expect(rateLimiter.getRemaining('test-key')).toBe(1);
+  it("should track remaining requests", () => {
+    expect(rateLimiter.getRemaining("test-key")).toBe(3);
+    rateLimiter.check("test-key");
+    expect(rateLimiter.getRemaining("test-key")).toBe(2);
+    rateLimiter.check("test-key");
+    expect(rateLimiter.getRemaining("test-key")).toBe(1);
   });
 
-  it('should reset after window expires', async () => {
-    rateLimiter.check('test-key');
-    rateLimiter.check('test-key');
-    rateLimiter.check('test-key');
-    expect(rateLimiter.check('test-key')).toBe(false);
+  it("should reset after window expires", async () => {
+    rateLimiter.check("test-key");
+    rateLimiter.check("test-key");
+    rateLimiter.check("test-key");
+    expect(rateLimiter.check("test-key")).toBe(false);
 
     // Wait for window to expire
-    await new Promise(resolve => setTimeout(resolve, 1100));
+    await new Promise((resolve) => setTimeout(resolve, 1100));
 
-    expect(rateLimiter.check('test-key')).toBe(true);
+    expect(rateLimiter.check("test-key")).toBe(true);
   });
 
-  it('should track different keys separately', () => {
-    rateLimiter.check('key1');
-    rateLimiter.check('key1');
-    rateLimiter.check('key1');
-    
-    expect(rateLimiter.check('key1')).toBe(false);
-    expect(rateLimiter.check('key2')).toBe(true);
+  it("should track different keys separately", () => {
+    rateLimiter.check("key1");
+    rateLimiter.check("key1");
+    rateLimiter.check("key1");
+
+    expect(rateLimiter.check("key1")).toBe(false);
+    expect(rateLimiter.check("key2")).toBe(true);
+  });
+
+  it("should not keep the event loop alive with its cleanup timer", () => {
+    // The cleanup interval must be unref'd: a ref'd timer would stop the
+    // process from exiting once its MCP client disconnects, leaking an orphan
+    // process that holds the entire server heap.
+    const timer = (
+      rateLimiter as unknown as { cleanupInterval: NodeJS.Timeout }
+    ).cleanupInterval;
+
+    expect(timer.hasRef()).toBe(false);
   });
 });
-

--- a/src/__tests__/serverLifecycle.test.ts
+++ b/src/__tests__/serverLifecycle.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Server lifecycle regression tests.
+ *
+ * The MCP stdio transport only listens for 'data'/'error' on stdin — it never
+ * detects that the client hung up. Combined with any timer that refs the event
+ * loop, a parent that disappears WITHOUT sending SIGINT/SIGTERM (crash, force
+ * quit, pipes simply closed) used to leave the server running forever as an
+ * orphan process holding its whole heap.
+ *
+ * These tests spawn the real server and assert it terminates on every
+ * disconnect path. They run the TypeScript entry through tsx because CI runs
+ * `npm test` before `npm run build`, so `dist/` may not exist yet.
+ */
+import { spawn, type ChildProcessWithoutNullStreams } from "child_process";
+import { fileURLToPath } from "url";
+import { dirname, join } from "path";
+
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ENTRY = join(REPO_ROOT, "src", "index.ts");
+
+// Generous so a cold tsx start on slow CI can't cause a false failure.
+const BOOT_TIMEOUT_MS = 30000;
+const EXIT_TIMEOUT_MS = 15000;
+const TEST_TIMEOUT_MS = 60000;
+
+const children: ChildProcessWithoutNullStreams[] = [];
+
+/** Spawn the server and resolve once it reports a successful start. */
+async function startServer(): Promise<ChildProcessWithoutNullStreams> {
+  // `--import tsx` rather than tsx's CLI: the CLI spawns a grandchild, which a
+  // kill on the direct child would not reap — leaking the very orphan
+  // processes these tests exist to prevent.
+  const child = spawn(process.execPath, ["--import", "tsx", ENTRY], {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      // No request is ever made; these only have to satisfy loadConfig().
+      COGNIGY_API_BASE_URL: "https://api-trial.cognigy.ai",
+      COGNIGY_API_KEY: "lifecycle-test-key",
+      LOG_LEVEL: "info",
+    },
+    stdio: ["pipe", "pipe", "pipe"],
+  });
+  children.push(child);
+
+  await new Promise<void>((resolve, reject) => {
+    const timer = setTimeout(
+      () => reject(new Error("server did not start in time")),
+      BOOT_TIMEOUT_MS,
+    );
+    let stderr = "";
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString();
+      if (stderr.includes("started successfully")) {
+        clearTimeout(timer);
+        resolve();
+      }
+    });
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      reject(new Error(`server exited during startup (code ${code} )`));
+    });
+  });
+
+  // Drop the startup 'exit' rejection listener so it can't fire later.
+  child.removeAllListeners("exit");
+  return child;
+}
+
+/** Resolve with the exit code, or reject if the process outlives the timeout. */
+function waitForExit(child: ChildProcessWithoutNullStreams): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(
+      () =>
+        reject(
+          new Error(
+            `server was still running ${EXIT_TIMEOUT_MS}ms after the client went away — it would leak as an orphan process`,
+          ),
+        ),
+      EXIT_TIMEOUT_MS,
+    );
+    child.once("exit", (code) => {
+      clearTimeout(timer);
+      resolve(code ?? 0);
+    });
+  });
+}
+
+// Reap survivors and wait for them to actually die, so a failing test can
+// neither leak a process nor leave Jest hanging on an open handle.
+afterEach(async () => {
+  await Promise.all(
+    children.splice(0).map(async (child) => {
+      if (child.exitCode !== null || child.signalCode !== null) return;
+      const dead = new Promise<void>((resolve) =>
+        child.once("exit", () => resolve()),
+      );
+      child.kill("SIGKILL");
+      await dead;
+    }),
+  );
+});
+
+describe("server lifecycle", () => {
+  it(
+    "exits when the client closes stdin (EOF, no signal)",
+    async () => {
+      const child = await startServer();
+      const exited = waitForExit(child);
+      child.stdin.end();
+      expect(await exited).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "exits when the stdin pipe is destroyed abruptly",
+    async () => {
+      const child = await startServer();
+      const exited = waitForExit(child);
+      child.stdin.destroy();
+      expect(await exited).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+
+  it(
+    "still exits on SIGTERM",
+    async () => {
+      const child = await startServer();
+      const exited = waitForExit(child);
+      child.kill("SIGTERM");
+      expect(await exited).toBe(0);
+    },
+    TEST_TIMEOUT_MS,
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -97,10 +97,18 @@ async function main() {
     const shutdown = async () => {
       if (shuttingDown) return;
       shuttingDown = true;
-      logger.info("Shutting down NiCE Cognigy Plugin");
-      rateLimiter.destroy();
-      await server.close();
-      process.exit(0);
+      // `finally` so a failing close can never strand the process: the guard
+      // above means a later signal won't retry, and this runs as an event
+      // listener, where a rejection would otherwise be unhandled.
+      try {
+        logger.info("Shutting down NiCE Cognigy Plugin");
+        rateLimiter.destroy();
+        await server.close();
+      } catch (error: any) {
+        logger.error("Error during shutdown", { error: error?.message });
+      } finally {
+        process.exit(0);
+      }
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,7 +93,10 @@ async function main() {
     await server.connect(transport);
     logger.info("NiCE Cognigy Plugin started successfully");
 
+    let shuttingDown = false;
     const shutdown = async () => {
+      if (shuttingDown) return;
+      shuttingDown = true;
       logger.info("Shutting down NiCE Cognigy Plugin");
       rateLimiter.destroy();
       await server.close();
@@ -101,6 +104,14 @@ async function main() {
     };
     process.on("SIGINT", shutdown);
     process.on("SIGTERM", shutdown);
+    // StdioServerTransport never listens for stdin ending — if the parent
+    // (Claude Code, or an `npx` wrapper) tears down the connection by closing
+    // the pipes instead of sending a signal, nothing here would otherwise
+    // notice. Without this, the RateLimiter's setInterval keeps the event
+    // loop alive forever, turning every such disconnect into an orphaned,
+    // memory-holding process. Treat stdin ending as a disconnect too.
+    process.stdin.on("end", shutdown);
+    process.stdin.on("close", shutdown);
   } catch (error: any) {
     logger.error("Failed to start MCP Server", {
       error: error.message,

--- a/src/utils/rateLimiter.ts
+++ b/src/utils/rateLimiter.ts
@@ -19,8 +19,14 @@ export class RateLimiter {
 
   constructor(config: RateLimitConfig) {
     this.config = config;
-    // Clean up expired entries every minute
+    // Clean up expired entries every minute. `unref()` so this housekeeping
+    // timer can never by itself keep the Node event loop alive — without it, a
+    // server whose client disconnected would linger forever as an orphan
+    // process holding its whole heap. Safe to unref: `check()` already expires
+    // records lazily, so the sweep is a pure memory-hygiene optimisation and
+    // skipping it while the process is otherwise idle costs nothing.
     this.cleanupInterval = setInterval(() => this.cleanup(), 60000);
+    this.cleanupInterval.unref();
   }
 
   /**
@@ -84,4 +90,3 @@ export class RateLimiter {
     }
   }
 }
-


### PR DESCRIPTION
## Summary

- Fix orphaned MCP server processes leaking memory: the server now shuts down when stdin ends/closes, not only on `SIGINT`/`SIGTERM`
- `@modelcontextprotocol/sdk`'s `StdioServerTransport` only listens for `'data'`/`'error'` on stdin and never detects that the client hung up — `onclose` fires only on an explicit `close()`. So a parent (Claude Code, or an `npx` wrapper) that tears down the connection by closing the pipes instead of sending a signal went unnoticed
- `RateLimiter`'s cleanup `setInterval` was the sole thing pinning the event loop, and it was only cleared inside `shutdown()` — so every such disconnect left a permanent orphan process holding the entire server heap
- Fixed on both axes (defence in depth), and locked in with regression tests

### Verified

Spawned the real server and simulated a parent going away **without a signal**:

| Variant | stdin EOF | abrupt pipe destroy | SIGTERM/SIGINT |
|---|---|---|---|
| before | 🔴 alive indefinitely | 🔴 alive indefinitely | ✅ ~143ms |
| after | ✅ exits ~150ms, code 0 | ✅ exits ~150ms, code 0 | ✅ ~150ms |

The new lifecycle tests were confirmed to fail 2/3 against the pre-fix code (the `SIGTERM` case correctly still passes).

## Changes

| File / Component | Description |
| --- | --- |
| `src/index.ts` | Route stdin `end`/`close` through the same shutdown path as `SIGINT`/`SIGTERM`, guarded so it runs once; exit from a `finally` so a rejecting `server.close()` can't strand the process or raise an unhandled rejection in an event listener |
| `src/utils/rateLimiter.ts` | `unref()` the cleanup interval so this housekeeping timer can never by itself hold the event loop open. Safe: the rate-limit key derives from the static API key (one map entry for the process lifetime) and `check()` already expires records lazily |
| `src/__tests__/serverLifecycle.test.ts` | New — spawns the real server and asserts it terminates on stdin EOF, abrupt pipe destroy, and `SIGTERM`. Uses `node --import tsx` because CI runs tests before the build, and because tsx's CLI spawns a grandchild a kill wouldn't reap |
| `src/__tests__/rateLimiter.test.ts` | Assert the cleanup timer is unref'd |

No changes to tool definitions, schemas, or the plugin manifest — nothing here affects marketplace submission requirements.

## Test plan

Automated — CI runs tests and Prettier checks on every PR via `.github/workflows/pr.yml`.

Locally: full suite green (428 passed, 3 skipped), typecheck clean, no leaked processes after the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)