### PR TITLE
fix: make auto-updates actually reach users on ChatGPT + Codex and Antigravity

### DIFF
--- a/.claude/skills/add-client-platform/SKILL.md
+++ b/.claude/skills/add-client-platform/SKILL.md
@@ -14,18 +14,19 @@ Verify against the client's **source or official docs**, not blog posts, and che
 1. Does it read an existing manifest of ours as a fallback? If so, what does the fallback *lose* (presentation fields, credential handling)?
 2. Does it interpolate credential placeholders (`${user_config.*}` or equivalent)? Most clients do **not** — see the credential rule below.
 3. Is there a CLI that owns its config file, or must we merge the file ourselves?
+4. **How does the client update an installed plugin?** See the update rule below — this is the question most easily assumed and most often wrong.
 
 Only the parts a fallback can't cover need new code.
 
 ## Pick the archetype
 
-| Archetype | Reference | How it works |
-|---|---|---|
-| Repo-marketplace plugin | `claude-code`, `codex` | Client discovers `plugin/.<client>-plugin/plugin.json` via a marketplace manifest in this repo. Installer drives the client CLI (`marketplace add`), user finishes in the client's plugin UI. |
-| Direct config merge | `claude-desktop` | No CLI. Installer reads/merges the client's own MCP config file, preserving every other key, and chmods it 0600 when it holds secrets. |
-| Packaged extension | `gemini` | A build script emits a release asset; installer runs the client's `extensions install` against the GitHub release. |
-| Stage and register | `antigravity` | The installer builds a plugin directory itself and writes the client's own registry entries — no client CLI involved, works before the client's first launch. |
-| Credentials only | `other-hosts` | The client installs the plugin itself (or takes a hand-written MCP entry); the installer writes `~/.cognigy-plugin/config.json` and wires nothing. |
+| Archetype | Reference | How it works | How updates reach the user |
+|---|---|---|---|
+| Repo-marketplace plugin | `claude-code`, `codex` | Client discovers `plugin/.<client>-plugin/plugin.json` via a marketplace manifest in this repo. Installer drives the client CLI (`marketplace add`), user finishes in the client's plugin UI. | The client re-checks the repo ref and swaps the cached plugin; the new manifest's engine pin pulls the matching engine. **Only works if the ref moves** — pin it to `main` explicitly. |
+| Direct config merge | `claude-desktop` | No CLI. Installer reads/merges the client's own MCP config file, preserving every other key, and chmods it 0600 when it holds secrets. | Nothing in the client updates. The MCP entry points at the launcher, which pulls `@latest` each boot. |
+| Packaged extension | `gemini` | A build script emits a release asset; installer runs the client's `extensions install` against the GitHub release. | The client's own extension auto-update, if it has one — install with that flag on. |
+| Stage and register | `antigravity` | The installer builds a plugin directory itself and writes the client's own registry entries — no client CLI involved, works before the client's first launch. | Nothing in the client updates — we staged the files, so we own refreshing them. The launcher re-stages them after an engine bump. |
+| Credentials only | `other-hosts` | The client installs the plugin itself (or takes a hand-written MCP entry); the installer writes `~/.cognigy-plugin/config.json` and wires nothing. | The host owns the version. Say so and stop. |
 
 Most new clients are archetype 1 or 2. "Stage and register" is the answer when the client has a real plugin format but its install command is unreliable to shell out to — see the Antigravity notes in `.claude/CLAUDE.md` for why reproducing the command beat calling it. Reach for "credentials only" when the client can already find and install the plugin but has no way to ask the user for an API key — that is the whole gap, so filling it is the whole install.
 
@@ -41,7 +42,7 @@ Most new clients are archetype 1 or 2. "Stage and register" is the answer when t
 | `.releaserc.json` | Add the same committed manifests to the `@semantic-release/git` assets. Add a build step to `prepareCmd` + a GitHub asset only if the client needs a packaged artifact (see `build-gemini-extension.mjs`). |
 | `src/__tests__/install<...>.test.ts` | Arg builders, config merge/remove round-trips, detection. Follow `installCodexGemini.test.ts`. |
 | `docs/install/<client>.md` | Install, credentials, update, uninstall — same four sections as the existing guides. |
-| `README.md` | Row in the per-client support table, link in the docs list, and the credentials paragraph if this client uses a different channel. |
+| `README.md` | Row in the per-client support table — including the **Auto-updates** cell — link in the docs list, and the credentials paragraph if this client uses a different channel. |
 
 Do **not** touch `src/index.ts`, the tools, or the skills — the MCP server itself is client-agnostic.
 
@@ -70,6 +71,16 @@ The **npm alias form is required in both cases**. A plain `@cognigy/plugin-engin
 
 **Fail loud vs. log-and-continue.** Throw when the load-bearing step fails (the MCP server never got wired) — and say in the error that creds are already written and which commands to run by hand. Log-and-continue for optional steps like `marketplace add`, which older client versions may not support; tools still work without it.
 
+**Work out how updates reach the user, and prove it.** This has been wrong twice, in both directions, and each time the docs asserted a behaviour nobody had checked. Answer three questions against the client's source or official docs:
+
+1. *Does the client refresh the plugin source on its own?* Codex does (it re-checks Git marketplaces at plugin startup); Antigravity does not (its CLI has no update command at all, and `agy plugin install` only copies a local directory).
+2. *Is anything pinned to something that stops moving?* A Git marketplace registered without an explicit ref inherits the branch of whatever checkout the installer ran in. Auto-update then works perfectly and finds nothing, forever. Pin refs explicitly.
+3. *Do plugin **files** update, or only the engine?* Skills and agents staged as plain files never change on their own. If the client won't refresh them, the launcher must — `updateAntigravity()` called from `desktopLauncher.ts`, version-gated so it runs once per release.
+
+Then wire `runUpdate()` to actually do the work. A branch that prints a claim instead of calling something is worse than no branch: it reads as covered in review and in the docs. Record the result in the README's **Auto-updates** column (Automatic / Enable once / Manual) rather than in prose.
+
+**The launcher can't update itself.** `~/.cognigy-plugin/desktop-launch.mjs` lives outside the versioned engine directory, so an engine bump never rewrites it. Any client whose install writes it must also rewrite it on update, or launcher fixes will never reach existing installs.
+
 **Detection probes both PATH and config dir.** A client's IDE extension or desktop app often shares the config directory without exposing a CLI. See the `codex`/`gemini` entries in `detectClients()`.
 
 **Every entry in `ALL_CLIENTS` needs a full lifecycle.** `runUninstall()` iterates the list, so a client with only an `install` branch silently does nothing when the user targets it with `--client`. If there is genuinely nothing to undo, say that and point at what does own the cleanup — don't leave the branch out.
@@ -78,7 +89,7 @@ The **npm alias form is required in both cases**. A plain `@cognigy/plugin-engin
 
 ## Steps
 
-1. Research the client: manifest schema, marketplace/discovery path, CLI surface, credential handling. Confirm against source or official docs.
+1. Research the client: manifest schema, marketplace/discovery path, CLI surface, credential handling, **and how it updates an installed plugin**. Confirm against source or official docs.
 2. Decide the archetype and the credential channel.
 3. Write `src/install/<client>.ts`, copying the closest existing module's structure and doc-comment style — the header comment should explain *why* the approach was chosen, not just what it does.
 4. Wire it into `src/setup.ts` (all seven touch points listed above).

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ npx -y -p @cognigy/plugin-engine@latest cognigy-setup \
 
 ## Staying up to date
 
-Updates are automatic on Claude Desktop (engine refreshes each launch), ChatGPT + Codex (the plugin runs the engine at `@latest`), Gemini CLI (installed with auto-update on), and Antigravity (the launcher pulls the latest engine each launch); on other hosts the host owns the plugin version. **Claude Code is the exception** — it leaves auto-update off for third-party marketplaces, so turn it on once under `/plugin → Marketplaces → cognigy-plugin`.
+Updates are automatic on Claude Desktop (engine refreshes each launch), ChatGPT + Codex (Codex re-checks the marketplace whenever plugins start up), Gemini CLI (installed with auto-update on), and Antigravity (the launcher pulls the latest engine each launch); on other hosts the host owns the plugin version. **Claude Code is the exception** — it leaves auto-update off for third-party marketplaces, so turn it on once under `/plugin → Marketplaces → cognigy-plugin`.
 
 Two caveats: on **Antigravity** the skills and agents are plugin _files_, so a newer engine's copies only land when you run `cognigy-setup update`. On **ChatGPT + Codex** skills update with the plugin, not the engine.
 

--- a/README.md
+++ b/README.md
@@ -75,12 +75,11 @@ What each client gets, and what (if anything) you finish by hand — full instru
 | **[Claude Desktop chat](docs/install/claude-desktop.md)**                 | ✅    | ✅     | ✅     | Install the plugin in-app             | Automatic                |
 | **[ChatGPT + Codex](docs/install/chatgpt-codex.md)** (CLI + IDE)          | ✅    | ✅     | —      | None                                  | Automatic                |
 | **[Google Gemini CLI](docs/install/gemini-cli.md)** (Code Assist only)    | ✅    | ✅     | ✅     | None                                  | Automatic                |
-| **[Antigravity](docs/install/antigravity.md)** (IDE + `agy` CLI)          | ✅    | ✅     | ✅     | None                                  | Automatic <sup>2</sup>   |
-| **[Other hosts](docs/install/other-hosts.md)** (VS Code, Cursor, …)       | ✅    | ✅     | ✅     | Install the plugin in the host itself | Manual <sup>3</sup>      |
+| **[Antigravity](docs/install/antigravity.md)** (IDE + `agy` CLI)          | ✅    | ✅     | ✅     | None                                  | Automatic                |
+| **[Other hosts](docs/install/other-hosts.md)** (VS Code, Cursor, …)       | ✅    | ✅     | ✅     | Install the plugin in the host itself | Manual <sup>2</sup>      |
 
 <sup>1</sup> Claude Code leaves auto-update off for third-party marketplaces — turn it on once under `/plugin → Marketplaces → cognigy-plugin`.
-<sup>2</sup> The engine updates on every launch; skills and agents are plugin _files_, so run `cognigy-setup update` to refresh those.
-<sup>3</sup> The host owns the plugin version.
+<sup>2</sup> The host owns the plugin version.
 
 <details>
 <summary>Scripting / CI</summary>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NiCE Cognigy Plugin
 
-> Distributed exclusively through each client's native plugin mechanism — a **plugin** on **Claude Code**, **Claude Desktop**, **ChatGPT + Codex**, and **Antigravity**, an **extension** on **Google Gemini CLI** — with more clients to come. Each package installs the server engine and ships skills + agents. Claude Code pins the engine to the plugin version; the other clients run it at `@latest` so fixes arrive without a reinstall.
+> Distributed exclusively through each client's native plugin mechanism — a **plugin** on **Claude Code**, **Claude Desktop**, **ChatGPT + Codex**, and **Antigravity**, an **extension** on **Google Gemini CLI** — with more clients to come. Each package installs the server engine and ships skills + agents.
 
 A plugin that connects your AI assistant to the [Cognigy.AI](https://www.cognigy.com) REST API. Create, test, and improve LLM-based AI Agents through a self-improvement loop — without leaving your client.
 
@@ -69,14 +69,18 @@ npx -y -p @cognigy/plugin-engine@latest cognigy-setup
 
 What each client gets, and what (if anything) you finish by hand — full instructions, Windows notes, and troubleshooting in each guide:
 
-| Client                                                                    | Tools | Skills | Agents | Extra step after the installer        |
-| ------------------------------------------------------------------------- | ----- | ------ | ------ | ------------------------------------- |
-| **[Claude Code](docs/install/claude-code.md)** (CLI + Desktop "Code" tab) | ✅    | ✅     | ✅     | None                                  |
-| **[Claude Desktop chat](docs/install/claude-desktop.md)**                 | ✅    | ✅     | ✅     | Install the plugin in-app             |
-| **[ChatGPT + Codex](docs/install/chatgpt-codex.md)** (CLI + IDE)          | ✅    | ✅     | —      | None                                  |
-| **[Google Gemini CLI](docs/install/gemini-cli.md)** (Code Assist only)    | ✅    | ✅     | ✅     | None                                  |
-| **[Antigravity](docs/install/antigravity.md)** (IDE + `agy` CLI)          | ✅    | ✅     | ✅     | None                                  |
-| **[Other hosts](docs/install/other-hosts.md)** (VS Code, Cursor, …)       | ✅    | ✅     | ✅     | Install the plugin in the host itself |
+| Client                                                                    | Tools | Skills | Agents | Extra step after the installer        | Auto-updates             |
+| ------------------------------------------------------------------------- | ----- | ------ | ------ | ------------------------------------- | ------------------------ |
+| **[Claude Code](docs/install/claude-code.md)** (CLI + Desktop "Code" tab) | ✅    | ✅     | ✅     | None                                  | Enable once <sup>1</sup> |
+| **[Claude Desktop chat](docs/install/claude-desktop.md)**                 | ✅    | ✅     | ✅     | Install the plugin in-app             | Automatic                |
+| **[ChatGPT + Codex](docs/install/chatgpt-codex.md)** (CLI + IDE)          | ✅    | ✅     | —      | None                                  | Automatic                |
+| **[Google Gemini CLI](docs/install/gemini-cli.md)** (Code Assist only)    | ✅    | ✅     | ✅     | None                                  | Automatic                |
+| **[Antigravity](docs/install/antigravity.md)** (IDE + `agy` CLI)          | ✅    | ✅     | ✅     | None                                  | Automatic <sup>2</sup>   |
+| **[Other hosts](docs/install/other-hosts.md)** (VS Code, Cursor, …)       | ✅    | ✅     | ✅     | Install the plugin in the host itself | Manual <sup>3</sup>      |
+
+<sup>1</sup> Claude Code leaves auto-update off for third-party marketplaces — turn it on once under `/plugin → Marketplaces → cognigy-plugin`.
+<sup>2</sup> The engine updates on every launch; skills and agents are plugin _files_, so run `cognigy-setup update` to refresh those.
+<sup>3</sup> The host owns the plugin version.
 
 <details>
 <summary>Scripting / CI</summary>
@@ -96,9 +100,11 @@ npx -y -p @cognigy/plugin-engine@latest cognigy-setup \
 
 ## Staying up to date
 
-Updates are automatic on Claude Desktop (engine refreshes each launch), ChatGPT + Codex (Codex re-checks the marketplace whenever plugins start up), Gemini CLI (installed with auto-update on), and Antigravity (the launcher pulls the latest engine each launch); on other hosts the host owns the plugin version. **Claude Code is the exception** — it leaves auto-update off for third-party marketplaces, so turn it on once under `/plugin → Marketplaces → cognigy-plugin`.
+See the **Auto-updates** column in the table above for what each client does on its own. To pull a new release now instead of waiting for the client to notice:
 
-Two caveats: on **Antigravity** the skills and agents are plugin _files_, so a newer engine's copies only land when you run `cognigy-setup update`. On **ChatGPT + Codex** skills update with the plugin, not the engine.
+```
+npx -y -p @cognigy/plugin-engine@latest cognigy-setup update
+```
 
 The installer doubles as a manager:
 

--- a/docs/install/antigravity.md
+++ b/docs/install/antigravity.md
@@ -2,13 +2,13 @@
 
 Antigravity has a first-class plugin format, so the installer builds a real plugin and installs it into `~/.gemini/config/plugins/cognigy-plugin/` — a tree shared by the **IDE**, the **`agy` CLI**, and the **SDK**, so one install serves all three.
 
-|                  |                                                                            |
-| ---------------- | -------------------------------------------------------------------------- |
-| **You get**      | Tools, skills, and agents — the full surface                               |
-| **Credentials**  | `~/.cognigy-plugin/config.json` (`chmod 600`) — never in mcp_config        |
-| **Extra steps**  | None — restart Antigravity                                                 |
-| **Requires**     | Nothing; the installer does not need `agy` on PATH                         |
-| **Auto-updates** | Engine yes, on every launch. Skills and agents need `cognigy-setup update` |
+|                  |                                                                         |
+| ---------------- | ----------------------------------------------------------------------- |
+| **You get**      | Tools, skills, and agents — the full surface                            |
+| **Credentials**  | `~/.cognigy-plugin/config.json` (`chmod 600`) — never in mcp_config     |
+| **Extra steps**  | None — restart Antigravity                                              |
+| **Requires**     | Nothing; the installer does not need `agy` on PATH                      |
+| **Auto-updates** | Yes — engine every launch, skills and agents on the launch after a bump |
 
 ## Install
 
@@ -44,15 +44,19 @@ The API key is **not** written into any `mcp_config.json` — that file is share
 
 ## Updating
 
-The engine auto-updates: the plugin's server runs through a launcher that pulls the latest engine on every Antigravity launch, offline-safe.
+Nothing to do. The plugin's server runs through a launcher that pulls the latest engine on every Antigravity launch (offline-safe), and on the first launch after a version bump that same launcher re-stages the plugin's skills and agents from the new engine. The engine is live immediately; the refreshed skills and agents load on the **next** launch, since Antigravity reads them at startup.
 
-Skills and agents are different — they are plain files staged at install time, so a newer engine's copies only land when you re-stage:
+This is ours, not Antigravity's: `agy` has no update command, no marketplace, and no refresh of its own — `agy plugin install` only ever copies a local directory.
+
+To pull a release now rather than at the next launch:
 
 ```
 npx -y -p @cognigy/plugin-engine@latest cognigy-setup update
 ```
 
 `cognigy-setup status` shows the installed plugin version next to the latest on npm.
+
+One caveat for existing installs: the launcher lives outside the versioned engine directory, so a launcher that predates this feature cannot update itself. Run `cognigy-setup update` once and it is rewritten; after that, updates are hands-off.
 
 ## Uninstall
 

--- a/docs/install/chatgpt-codex.md
+++ b/docs/install/chatgpt-codex.md
@@ -76,6 +76,20 @@ codex mcp remove cognigy
 
 **Credentials.** `config.toml` has no keychain, and Codex cannot prompt a plugin for secrets, so the installer keeps them out of it entirely: `~/.cognigy-plugin/config.json` (`chmod 600`), which the engine reads whenever `COGNIGY_API_BASE_URL` / `COGNIGY_API_KEY` are absent from the environment. Exported env vars still win if you prefer to set them per shell.
 
-**Updates.** The plugin's server runs the engine at `@latest`, so tools pick up new releases on restart. Skills ship with the plugin and update when it does.
+**Updates are automatic.** Codex re-checks its configured Git marketplaces every time plugins start up, and replaces the cached plugin when the branch has moved ([openai/codex#17425](https://github.com/openai/codex/pull/17425), on by default since April 2026). A new plugin version carries a new engine pin, so the tools follow along. In practice: restart the app now and then and you are current.
+
+To force it immediately instead of waiting for the next app start:
+
+```
+npx -y -p @cognigy/plugin-engine@latest cognigy-setup update
+```
+
+**If you are stuck on an old version**, the marketplace is almost certainly pinned to a branch that has stopped moving — auto-upgrade then works perfectly and finds nothing, forever. Check the ref:
+
+```
+codex plugin marketplace list
+```
+
+The installer registers the marketplace with `--ref main` precisely to prevent this. Without that ref, `codex plugin marketplace add Cognigy/cognigy-plugin` takes the branch from whatever Git checkout you ran it in. Re-running the installer detects a non-`main` ref and re-pins it for you.
 
 **Project-scoped config is ignored by the desktop app** — it loads only the global `~/.codex/config.toml` ([openai/codex#13025](https://github.com/openai/codex/issues/13025)). Plugins are recorded there, so this doesn't affect you.

--- a/src/__tests__/install.test.ts
+++ b/src/__tests__/install.test.ts
@@ -28,6 +28,7 @@ import {
   fallbackCommands,
 } from "../install/claudeCode.js";
 import { quoteWinArgs, resolveNpmCli } from "../install/npmRunner.js";
+import * as antigravity from "../install/antigravity.js";
 import {
   DESKTOP_LAUNCHER_SOURCE,
   writeDesktopLauncher,
@@ -289,6 +290,39 @@ describe("writeDesktopLauncher", () => {
     expect(DESKTOP_LAUNCHER_SOURCE).toContain("@cognigy/plugin-engine");
     // stdout must never be written to — diagnostics go to stderr only.
     expect(DESKTOP_LAUNCHER_SOURCE).not.toContain("process.stdout.write");
+  });
+
+  it("re-stages the Antigravity plugin before handing off, and only on a bump", () => {
+    // Antigravity ships no update command and no marketplace, so this step is
+    // the only thing that makes its skills and agents track the engine.
+    expect(DESKTOP_LAUNCHER_SOURCE).toContain("syncAntigravityPlugin");
+    expect(DESKTOP_LAUNCHER_SOURCE).toContain(
+      '"dist", "install", "antigravity.js"',
+    );
+    // Version-gated: once per release, not every boot.
+    expect(DESKTOP_LAUNCHER_SOURCE).toContain("staged === engine");
+    // Must run before the engine import, which never returns.
+    expect(
+      DESKTOP_LAUNCHER_SOURCE.indexOf("await syncAntigravityPlugin()"),
+    ).toBeLessThan(
+      DESKTOP_LAUNCHER_SOURCE.indexOf("pathToFileURL(engineEntry)"),
+    );
+    // A failure here must never take the server down with it.
+    expect(DESKTOP_LAUNCHER_SOURCE).toContain(
+      "could not refresh Antigravity plugin files",
+    );
+  });
+
+  it("calls only symbols antigravity.ts actually exports", () => {
+    // The launcher is a STRING — tsc cannot see these calls, so a rename in
+    // antigravity.ts would break auto-update silently at runtime.
+    const called = [
+      ...DESKTOP_LAUNCHER_SOURCE.matchAll(/\bmod\.([A-Za-z0-9_]+)/g),
+    ].map((m) => m[1]);
+    expect(called.length).toBeGreaterThan(0);
+    for (const name of called) {
+      expect(Object.keys(antigravity)).toContain(name);
+    }
   });
 });
 

--- a/src/__tests__/installCodexGemini.test.ts
+++ b/src/__tests__/installCodexGemini.test.ts
@@ -5,10 +5,12 @@ import { join } from "path";
 import {
   buildCodexMarketplaceAddArgs,
   buildCodexMarketplaceRemoveArgs,
+  buildCodexMarketplaceUpgradeArgs,
   buildCodexPluginAddArgs,
   buildCodexPluginRemoveArgs,
   codexGuiSteps,
   codexHasCognigyPlugin,
+  readCodexMarketplaceRef,
 } from "../install/codex.js";
 import {
   buildGeminiInstallArgs,
@@ -29,12 +31,17 @@ afterEach(() => {
 });
 
 describe("codex arg building", () => {
-  it("marketplace add takes the owner/repo SOURCE", () => {
+  it("marketplace add takes the owner/repo SOURCE, pinned to main", () => {
+    // The --ref is load-bearing: without it Codex resolves the ref from the
+    // git checkout the installer runs in, which pins the snapshot to a feature
+    // branch that stops moving once merged.
     expect(buildCodexMarketplaceAddArgs()).toEqual([
       "plugin",
       "marketplace",
       "add",
       "Cognigy/cognigy-plugin",
+      "--ref",
+      "main",
     ]);
   });
 
@@ -62,12 +69,21 @@ describe("codex arg building", () => {
     ]);
   });
 
+  it("marketplace upgrade takes no target", () => {
+    expect(buildCodexMarketplaceUpgradeArgs()).toEqual([
+      "plugin",
+      "marketplace",
+      "upgrade",
+    ]);
+  });
+
   it("no arg builder wires a global mcp server", () => {
     // The plugin declares its own `platform` server; a global
     // [mcp_servers.cognigy] entry would be a duplicate engine.
     const all = [
       ...buildCodexMarketplaceAddArgs(),
       ...buildCodexMarketplaceRemoveArgs(),
+      ...buildCodexMarketplaceUpgradeArgs(),
       ...buildCodexPluginAddArgs(),
       ...buildCodexPluginRemoveArgs(),
     ];
@@ -79,7 +95,7 @@ describe("codex arg building", () => {
     // is registered from a different source string (the HTTPS URL the GUI
     // writes, or a branch ref), so the installer must not treat that as fatal.
     // Encoding the asymmetry here keeps the two from being "unified" later.
-    const add = buildCodexMarketplaceAddArgs().at(-1);
+    const add = buildCodexMarketplaceAddArgs()[3];
     const remove = buildCodexMarketplaceRemoveArgs().at(-1);
     expect(add).toContain("/");
     expect(remove).not.toContain("/");
@@ -109,6 +125,53 @@ describe("codexHasCognigyPlugin", () => {
       `[plugins."github@openai-curated"]\nenabled = true\n\n[mcp_servers.cognigy]\ncommand = "npx"\n`,
     );
     expect(codexHasCognigyPlugin(config)).toBe(false);
+  });
+});
+
+describe("readCodexMarketplaceRef", () => {
+  it("reads the ref of our git marketplace", () => {
+    const config = join(tmp(), "config.toml");
+    writeFileSync(
+      config,
+      `model = "gpt-5"\n\n[marketplaces.cognigy-plugin]\nsource_type = "git"\n` +
+        `source = "https://github.com/Cognigy/cognigy-plugin.git"\nref = "main"\n`,
+    );
+    expect(readCodexMarketplaceRef(config)).toBe("main");
+  });
+
+  it("reports a stale branch ref so the installer can re-pin it", () => {
+    // The 1.8.3-forever bug: installed from a checkout on a feature branch,
+    // which then merged and stopped moving.
+    const config = join(tmp(), "config.toml");
+    writeFileSync(
+      config,
+      `[marketplaces.cognigy-plugin]\nsource_type = "git"\n` +
+        `ref = "feat/plugin-platforms-codex-gemini"\n\n[marketplaces.openai-bundled]\n` +
+        `source_type = "local"\nref = "not-ours"\n`,
+    );
+    expect(readCodexMarketplaceRef(config)).toBe(
+      "feat/plugin-platforms-codex-gemini",
+    );
+  });
+
+  it("is null for a local source, another marketplace, or no file", () => {
+    const dir = tmp();
+    expect(readCodexMarketplaceRef(join(dir, "nope.toml"))).toBe(null);
+
+    // A local source is a developer's own wiring — never re-pin it.
+    const local = join(dir, "local.toml");
+    writeFileSync(
+      local,
+      `[marketplaces.cognigy-plugin]\nsource_type = "local"\nsource = "/tmp/x"\n`,
+    );
+    expect(readCodexMarketplaceRef(local)).toBe(null);
+
+    const other = join(dir, "other.toml");
+    writeFileSync(
+      other,
+      `[marketplaces.openai-bundled]\nsource_type = "git"\nref = "main"\n`,
+    );
+    expect(readCodexMarketplaceRef(other)).toBe(null);
   });
 });
 

--- a/src/install/antigravity.ts
+++ b/src/install/antigravity.ts
@@ -539,9 +539,18 @@ export function installAntigravity(
 }
 
 /**
- * Re-stage and re-register the plugin from this engine's shipped assets. Used by
- * `cognigy-setup update`: the engine itself auto-updates via the launcher, but
- * skills and agents are plain files that only change when we rewrite them.
+ * Re-stage and re-register the plugin from this engine's shipped assets.
+ *
+ * Called from two places: `cognigy-setup update`, and the launcher itself on
+ * the first boot after an engine bump (see desktopLauncher.ts) — which is what
+ * makes Antigravity's skills and agents track the engine without the user
+ * running anything. Antigravity has no update command and no marketplace, so
+ * nothing else would ever rewrite these files.
+ *
+ * The launcher is rewritten here too. It lives outside the versioned engine
+ * dir, so launcher-code fixes reach existing installs only when something
+ * rewrites it; without this an old launcher would keep running forever.
+ *
  * Credentials are left untouched.
  */
 export function updateAntigravity(): RegisterResult & {
@@ -552,6 +561,7 @@ export function updateAntigravity(): RegisterResult & {
   // install is touched — otherwise an assetless engine would quietly replace a
   // working plugin with an empty one.
   const staged = stagePluginDir();
+  writeDesktopLauncher();
   return {
     ...registerPlugin(staged.dir),
     skills: staged.skills,

--- a/src/install/codex.ts
+++ b/src/install/codex.ts
@@ -207,7 +207,7 @@ export function installCodex(creds: UserConfigFile): CodexResult {
   const mp = runCliTool("codex", codexPath, buildCodexMarketplaceAddArgs());
   if (mp.status !== 0 || mp.error) {
     process.stderr.write(
-      `[cognigy] 'codex plugin marketplace add ${MARKETPLACE_SOURCE}' exited ${mp.status}; ` +
+      `[cognigy] 'codex ${buildCodexMarketplaceAddArgs().join(" ")}' exited ${mp.status}; ` +
         `continuing — '${MARKETPLACE_NAME}' may already be registered from another source.\n`,
     );
   }
@@ -261,8 +261,6 @@ export interface CodexUpdateResult {
   refreshed?: boolean;
   /** Whether re-adding the plugin from the refreshed snapshot succeeded. */
   reinstalled?: boolean;
-  /** Fallback path: what to run by hand. */
-  commands?: string[];
 }
 
 /**
@@ -273,16 +271,12 @@ export interface CodexUpdateResult {
  * directory, which is what actually moves the installed version forward.
  */
 export function updateCodex(): CodexUpdateResult {
+  // Without the CLI there is nothing to fall back to, and nothing to worry
+  // about: Codex refreshes the marketplace itself when plugins next start up.
+  // Printing `codex ...` commands to someone who has no `codex` would be worse
+  // than saying so — the caller reports the restart instead.
   const codexPath = detectCodexPath();
-  if (!codexPath) {
-    return {
-      method: "fallback",
-      commands: [
-        `codex ${buildCodexMarketplaceUpgradeArgs().join(" ")}`,
-        `codex ${buildCodexPluginAddArgs().join(" ")}`,
-      ],
-    };
-  }
+  if (!codexPath) return { method: "fallback" };
 
   const up = runCliTool("codex", codexPath, buildCodexMarketplaceUpgradeArgs());
   const refreshed = up.status === 0 && !up.error;

--- a/src/install/codex.ts
+++ b/src/install/codex.ts
@@ -18,9 +18,26 @@
  * (src/config.ts).
  *
  * Everything else is `codex plugin`, which is fully non-interactive:
- *   codex plugin marketplace add Cognigy/cognigy-plugin
+ *   codex plugin marketplace add Cognigy/cognigy-plugin --ref main
  *   codex plugin add cognigy@cognigy-plugin
  * Without the CLI we print the equivalent GUI steps.
+ *
+ * `--ref main` is not optional, and it is what makes updates work at all.
+ * Codex auto-upgrades git marketplaces on plugin startup (openai/codex#17425,
+ * default-on since April 2026): it runs `git ls-remote`, compares against the
+ * recorded `last_revision`, and replaces the cached plugin when the ref has
+ * moved. A new plugin.json then carries a new exact engine pin, so npx fetches
+ * the matching engine — the whole chain updates on its own.
+ *
+ * That only holds if the ref MOVES. Given a bare `owner/repo`, Codex resolves
+ * the ref from the git checkout it is invoked in, so running the installer
+ * from a clone of THIS repo on a feature branch pins the marketplace to that
+ * branch. Once the branch merges and stops moving, `ls-remote` keeps returning
+ * the same revision and auto-upgrade correctly does nothing — forever.
+ * Observed live: a snapshot stuck at 1.8.3 while npm and main were at 1.10.0.
+ *
+ * So the fix is the pin, not a manual update path. `updateCodex` exists only
+ * to force the refresh immediately rather than at the next app start.
  */
 import { existsSync, readFileSync } from "fs";
 import { homedir } from "os";
@@ -32,6 +49,8 @@ import { detectOnPath, runCliTool } from "./cliRunner.js";
 const PLUGIN_NAME = "cognigy";
 /** Marketplace *source* — what `marketplace add` takes (owner/repo). */
 const MARKETPLACE_SOURCE = "Cognigy/cognigy-plugin";
+/** The only ref users should ever be pinned to. See the note at the top. */
+export const MARKETPLACE_REF = "main";
 /**
  * Marketplace *name* — the `name` field of .claude-plugin/marketplace.json,
  * which is what Codex registers it as and what `marketplace remove` takes.
@@ -48,9 +67,21 @@ export function detectCodexPath(): string | null {
   return detectOnPath("codex");
 }
 
-/** `codex plugin marketplace add Cognigy/cognigy-plugin`. */
+/** `codex plugin marketplace add Cognigy/cognigy-plugin --ref main`. */
 export function buildCodexMarketplaceAddArgs(): string[] {
-  return ["plugin", "marketplace", "add", MARKETPLACE_SOURCE];
+  return [
+    "plugin",
+    "marketplace",
+    "add",
+    MARKETPLACE_SOURCE,
+    "--ref",
+    MARKETPLACE_REF,
+  ];
+}
+
+/** `codex plugin marketplace upgrade` — refresh every git snapshot. */
+export function buildCodexMarketplaceUpgradeArgs(): string[] {
+  return ["plugin", "marketplace", "upgrade"];
 }
 
 /** `codex plugin marketplace remove cognigy-plugin` (by name, not source). */
@@ -84,6 +115,37 @@ export function codexHasCognigyPlugin(
   } catch {
     return false;
   }
+}
+
+/**
+ * The ref our marketplace is currently pinned to, or null when it is not
+ * registered as a git source (absent, or a local path a developer wired by
+ * hand — which we must leave alone).
+ *
+ * Scoped to the `[marketplaces.cognigy-plugin]` table on purpose: config.toml
+ * is the user's file and holds unrelated secrets, so we read the one block we
+ * own and never parse or rewrite the rest (the codex CLI does the writing).
+ */
+export function readCodexMarketplaceRef(
+  configPath: string = CODEX_CONFIG_PATH,
+): string | null {
+  if (!existsSync(configPath)) return null;
+  let block: string;
+  try {
+    const toml = readFileSync(configPath, "utf8");
+    const start = toml.search(
+      new RegExp(`^\\[marketplaces\\.${MARKETPLACE_NAME}\\]`, "m"),
+    );
+    if (start === -1) return null;
+    const rest = toml.slice(start);
+    // Index 0 is our own table header, so search from 1 for the next one.
+    const next = rest.slice(1).search(/^\[/m);
+    block = next === -1 ? rest : rest.slice(0, next + 1);
+  } catch {
+    return null;
+  }
+  if (!/^source_type\s*=\s*"git"/m.test(block)) return null;
+  return /^ref\s*=\s*"([^"]*)"/m.exec(block)?.[1] ?? null;
 }
 
 /** The in-app steps, for when the codex CLI isn't available. */
@@ -122,11 +184,26 @@ export function installCodex(creds: UserConfigFile): CodexResult {
     return { method: "fallback", configFile, guiSteps: codexGuiSteps() };
   }
 
-  // Re-adding the SAME source exits 0, but a marketplace already registered
-  // under this name from a *different* source string — the HTTPS URL the GUI
-  // writes, or a branch ref used for testing — is a hard error. That is not a
-  // failure for us: the marketplace we need is there either way, so fall
-  // through and let `plugin add` be the judge.
+  // A marketplace already registered under this name from a *different* source
+  // string makes `marketplace add` a hard error, so a stale git ref would
+  // survive every re-run of the installer — and `marketplace upgrade` would
+  // keep reporting it up to date, because a merged branch really is. Drop the
+  // registration first so the add below can re-pin it to main. Only for git
+  // sources on the wrong ref: a local source is a developer's own wiring.
+  const ref = readCodexMarketplaceRef();
+  if (ref !== null && ref !== MARKETPLACE_REF) {
+    process.stderr.write(
+      `[cognigy] marketplace '${MARKETPLACE_NAME}' is pinned to '${ref}'; ` +
+        `re-pinning to '${MARKETPLACE_REF}' so updates can reach you.\n`,
+    );
+    // The plugin holds a reference to the marketplace, so it goes first.
+    runCliTool("codex", codexPath, buildCodexPluginRemoveArgs());
+    runCliTool("codex", codexPath, buildCodexMarketplaceRemoveArgs());
+  }
+
+  // Re-adding the SAME source exits 0; anything else is not fatal for us,
+  // because the marketplace we need is registered either way. Fall through and
+  // let `plugin add` be the judge.
   const mp = runCliTool("codex", codexPath, buildCodexMarketplaceAddArgs());
   if (mp.status !== 0 || mp.error) {
     process.stderr.write(
@@ -176,4 +253,42 @@ export function uninstallCodex(): CodexUninstallResult {
   const removedMarketplace = rmMarket.status === 0 && !rmMarket.error;
 
   return { method: "cli", removedPlugin, removedMarketplace };
+}
+
+export interface CodexUpdateResult {
+  method: CodexMethod;
+  /** Whether the git snapshot refresh succeeded. */
+  refreshed?: boolean;
+  /** Whether re-adding the plugin from the refreshed snapshot succeeded. */
+  reinstalled?: boolean;
+  /** Fallback path: what to run by hand. */
+  commands?: string[];
+}
+
+/**
+ * Update the Codex install. Neither half of it auto-updates: the marketplace
+ * is a pinned git snapshot, and the manifest pins the engine to an exact
+ * version. So refresh the snapshot, then re-add the plugin — `plugin add` is
+ * idempotent and copies the snapshot's current version into a versioned cache
+ * directory, which is what actually moves the installed version forward.
+ */
+export function updateCodex(): CodexUpdateResult {
+  const codexPath = detectCodexPath();
+  if (!codexPath) {
+    return {
+      method: "fallback",
+      commands: [
+        `codex ${buildCodexMarketplaceUpgradeArgs().join(" ")}`,
+        `codex ${buildCodexPluginAddArgs().join(" ")}`,
+      ],
+    };
+  }
+
+  const up = runCliTool("codex", codexPath, buildCodexMarketplaceUpgradeArgs());
+  const refreshed = up.status === 0 && !up.error;
+
+  const add = runCliTool("codex", codexPath, buildCodexPluginAddArgs());
+  const reinstalled = add.status === 0 && !add.error;
+
+  return { method: "cli", refreshed, reinstalled };
 }

--- a/src/install/desktopLauncher.ts
+++ b/src/install/desktopLauncher.ts
@@ -23,9 +23,13 @@
  *      not hang Desktop boot).
  *   2. If newer than the installed engine, `npm install` it BEFORE handing off,
  *      so the new version is live the same boot.
- *   3. Hand off by importing the engine's dist/index.js (which self-invokes
+ *   3. Re-stage the Antigravity plugin's skills/agents when the engine moved
+ *      (no-op for Desktop, which has no plugin dir). Antigravity ships no
+ *      update command, no marketplace and no refresh of its own — see
+ *      antigravity.ts — so plugin files only track the engine if we do it here.
+ *   4. Hand off by importing the engine's dist/index.js (which self-invokes
  *      main() and connects the MCP stdio transport).
- *   4. Offline-safe: if the probe/install fails or times out but an engine is
+ *   5. Offline-safe: if the probe/install fails or times out but an engine is
  *      already on disk, boot it and warn on stderr. Hard-fail only when no engine
  *      exists at all (first-ever boot while offline).
  *
@@ -138,6 +142,27 @@ if (!existsSync(engineEntry)) {
   note(\`connect to a network and restart your client, or re-run: npx -y -p \${PKG}@latest cognigy-setup\`);
   process.exit(1);
 }
+
+// Antigravity keeps skills and agents as plain files inside its plugin dir and
+// has no update command, marketplace, or refresh of its own, so they only track
+// the engine if we re-stage them. Version-gated: this runs once per release, not
+// every boot. A no-op wherever no Cognigy plugin dir exists (Claude Desktop).
+async function syncAntigravityPlugin() {
+  try {
+    const mod = await import(
+      pathToFileURL(join(engineDir, "dist", "install", "antigravity.js")).href
+    );
+    if (!mod.antigravityHasPlugin?.()) return;
+    const staged = mod.installedPluginVersion?.() ?? null;
+    const engine = installedVersion();
+    if (!engine || staged === engine) return;
+    mod.updateAntigravity();
+    note(\`refreshed Antigravity skills/agents \${staged ?? "none"} -> \${engine}; restart Antigravity to load them\`);
+  } catch (err) {
+    note(\`could not refresh Antigravity plugin files: \${err?.message ?? err}\`);
+  }
+}
+await syncAntigravityPlugin();
 
 await import(pathToFileURL(engineEntry).href);
 `;

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -701,7 +701,16 @@ function runUpdate(): void {
   // who never wanted one.
   if (codexHasCognigyPlugin()) {
     const cx = updateCodex();
-    if (cx.method === "cli" && cx.reinstalled) {
+    if (cx.method === "fallback") {
+      // No CLI to drive, and nothing to do: Codex refreshes the marketplace
+      // itself at the next start. Printing `codex ...` here would be useless
+      // advice for someone who demonstrably has no `codex`.
+      process.stdout.write(
+        dim(
+          "• ChatGPT + Codex: 'codex' CLI not found — restart the app instead; it refreshes plugins itself on startup.\n",
+        ),
+      );
+    } else if (cx.refreshed && cx.reinstalled) {
       process.stdout.write(
         green("✓ ChatGPT + Codex") +
           ": marketplace refreshed and plugin re-installed. Restart the app (or start a new thread) to apply.\n" +
@@ -709,19 +718,23 @@ function runUpdate(): void {
             "  (Codex would have picked this up on its own at the next app start.)\n",
           ),
       );
-    } else if (cx.method === "cli") {
+    } else if (cx.reinstalled) {
+      // `plugin add` re-installed from a snapshot the upgrade failed to move,
+      // so this may well be the version already installed. Don't call it a
+      // refresh.
+      process.stdout.write(
+        yellow("• ChatGPT + Codex") +
+          ": plugin re-installed, but refreshing the marketplace failed — you may still be on the previous version.\n" +
+          dim(
+            "  Codex retries the refresh on its own at the next app start.\n",
+          ),
+      );
+    } else {
       process.stdout.write(
         yellow("• ChatGPT + Codex") +
           ": update failed — run it by hand:\n" +
           cyan("    codex plugin marketplace upgrade\n") +
           cyan("    codex plugin add cognigy@cognigy-plugin\n"),
-      );
-    } else {
-      process.stdout.write(
-        yellow("• ChatGPT + Codex") +
-          ": 'codex' CLI not found. To update, run:\n" +
-          (cx.commands ?? []).map((c) => cyan(`    ${c}`)).join("\n") +
-          "\n",
       );
     }
   } else {

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -48,6 +48,10 @@ import {
 } from "./install/antigravity.js";
 import { detectOnPath } from "./install/cliRunner.js";
 import {
+  DESKTOP_LAUNCHER_FILE,
+  writeDesktopLauncher,
+} from "./install/desktopLauncher.js";
+import {
   codexGuiSteps,
   codexHasCognigyPlugin,
   installCodex,
@@ -682,6 +686,10 @@ function runUpdate(): void {
         "\n",
     );
   }
+  // The launcher lives outside the versioned engine dir, so it is the one file
+  // an engine bump cannot refresh. Rewrite it — but only where one already
+  // exists, so this never creates a launcher on a machine using neither client.
+  if (existsSync(DESKTOP_LAUNCHER_FILE)) writeDesktopLauncher();
   process.stdout.write(
     dim(
       "• Claude Desktop chat connector auto-updates its engine on every restart — nothing to do.\n",
@@ -728,7 +736,10 @@ function runUpdate(): void {
     const ag = updateAntigravity();
     process.stdout.write(
       green("✓ Antigravity") +
-        `: plugin re-synced (${ag.skills.length} skills, ${ag.agents.length} agents). Restart Antigravity to apply.\n`,
+        `: plugin re-synced (${ag.skills.length} skills, ${ag.agents.length} agents). Restart Antigravity to apply.\n` +
+        dim(
+          "  (From now on the launcher does this itself on the first launch after a release.)\n",
+        ),
     );
   } else {
     process.stdout.write(

--- a/src/setup.ts
+++ b/src/setup.ts
@@ -52,6 +52,7 @@ import {
   codexHasCognigyPlugin,
   installCodex,
   uninstallCodex,
+  updateCodex,
 } from "./install/codex.js";
 import {
   installGemini,
@@ -686,11 +687,40 @@ function runUpdate(): void {
       "• Claude Desktop chat connector auto-updates its engine on every restart — nothing to do.\n",
     ),
   );
-  process.stdout.write(
-    dim(
-      "• ChatGPT + Codex: the plugin runs the engine @latest — restart to pick up a new release.\n",
-    ),
-  );
+  // Codex auto-upgrades git marketplaces on plugin startup, so this is only a
+  // "don't wait for the next app start" nudge. Only touch it when the plugin
+  // is actually installed, so `plugin add` can't register a plugin for someone
+  // who never wanted one.
+  if (codexHasCognigyPlugin()) {
+    const cx = updateCodex();
+    if (cx.method === "cli" && cx.reinstalled) {
+      process.stdout.write(
+        green("✓ ChatGPT + Codex") +
+          ": marketplace refreshed and plugin re-installed. Restart the app (or start a new thread) to apply.\n" +
+          dim(
+            "  (Codex would have picked this up on its own at the next app start.)\n",
+          ),
+      );
+    } else if (cx.method === "cli") {
+      process.stdout.write(
+        yellow("• ChatGPT + Codex") +
+          ": update failed — run it by hand:\n" +
+          cyan("    codex plugin marketplace upgrade\n") +
+          cyan("    codex plugin add cognigy@cognigy-plugin\n"),
+      );
+    } else {
+      process.stdout.write(
+        yellow("• ChatGPT + Codex") +
+          ": 'codex' CLI not found. To update, run:\n" +
+          (cx.commands ?? []).map((c) => cyan(`    ${c}`)).join("\n") +
+          "\n",
+      );
+    }
+  } else {
+    process.stdout.write(
+      dim("• ChatGPT + Codex: plugin not installed — nothing to update.\n"),
+    );
+  }
   // Antigravity's engine auto-updates via the launcher, but the plugin's skills
   // and agents are plain files — only a re-stage picks up a newer engine's copy.
   // Must run before the Gemini block below, which returns early.


### PR DESCRIPTION
## Summary

Auto-updates were broken on two clients, in two different ways, and the docs asserted update behaviour on both that nobody had verified. Fixed here, with the README stating each client's behaviour in a column instead of a paragraph that has to be reworded every time a client is added.

- **ChatGPT + Codex — frozen by a stale marketplace ref.** Codex *does* auto-update plugins: it re-checks configured Git marketplaces on plugin startup ([openai/codex#17425](https://github.com/openai/codex/pull/17425), default-on since April 2026), comparing `git ls-remote` against the recorded `last_revision` and replacing the cached plugin when the ref has moved. But given a bare `owner/repo`, Codex resolves the ref from the Git checkout the installer runs in — so installing from a clone of this repo on a feature branch pinned the marketplace there. Once that branch merged and stopped moving, auto-upgrade correctly found nothing, forever. Observed live: a ChatGPT install frozen at **1.8.3** while npm and `main` were both at **1.10.0**.
- **Antigravity — skills and agents never updated at all.** Antigravity has no mechanism for this: its [official CLI docs](https://antigravity.google/docs/cli/plugins) list only `agy plugin list | install | enable | disable | uninstall`, `agy plugin install` takes a local directory rather than a remote source, and there is no marketplace or refresh. Plugin files sat untouched from the day they were staged while the engine moved on. The launcher already runs on every boot to pull the latest engine, so it now re-stages skills and agents when the engine version has moved.
- **Docs corrected.** The README and the ChatGPT + Codex guide claimed the plugin runs the engine at `@latest`. It never has — the manifest pins it exactly, which is the point of the plugin/engine version lockstep.
- **Skill updated** so the next client doesn't repeat this. The update lifecycle was the one thing `add-client-platform` said nothing about.

No breaking changes. Codex users on a stale ref are repaired the next time they run the installer. Antigravity users need one `cognigy-setup update` to pick up the new launcher, and are hands-off from then on.

Contains a `feat` commit, so this releases a **minor**.

## Changes

| File / Component | Description |
| ---------------- | ----------- |
| `src/install/codex.ts` | `buildCodexMarketplaceAddArgs` now passes `--ref main`, so a fresh install can never inherit a branch. New `readCodexMarketplaceRef` reads the ref from the `[marketplaces.cognigy-plugin]` block of `config.toml` (scoped to that one table — the file is the user's and holds unrelated secrets). `installCodex` uses it to drop and re-add a Git registration pinned anywhere other than `main`; a `local` source is left alone, since that is a developer's own wiring. New `buildCodexMarketplaceUpgradeArgs` and `updateCodex` force a refresh now rather than at the next app start. |
| `src/install/desktopLauncher.ts` | After the engine check, the generated launcher imports the engine's own `dist/install/antigravity.js` and calls `updateAntigravity()` when the staged plugin version differs from the engine's — once per release, not every boot. Wrapped in try/catch and gated on a plugin directory existing, so a failure cannot take the MCP server down and Claude Desktop (which shares this launcher) skips it entirely. |
| `src/install/antigravity.ts` | `updateAntigravity` now rewrites the launcher too. It lives outside the versioned engine directory, so it is the one file an engine bump cannot refresh — without this, launcher fixes would never reach an existing install. |
| `src/setup.ts` | `runUpdate` did nothing at all for Codex; it now calls `updateCodex`, gated on the plugin being installed. It also refreshes the Desktop launcher, but only where one already exists, so it cannot create one on a machine using neither client. |
| `README.md` | New **Auto-updates** column on the per-client table — Automatic / Enable once / Manual — replacing the prose paragraph. Also drops the header's claim that only Claude Code pins the engine: Codex and Gemini pin it too; only Claude Desktop and Antigravity float, via the launcher. |
| `docs/install/chatgpt-codex.md` | Replaces the false `@latest` paragraph with how Codex's auto-upgrade actually works, the command to force it early, and a "stuck on an old version?" section pointing at `codex plugin marketplace list`. |
| `docs/install/antigravity.md` | Updating section rewritten: nothing to do, why this is ours rather than Antigravity's, and the one-launch lag before refreshed skills load. |
| `.claude/skills/add-client-platform/SKILL.md` | The update lifecycle was the one thing the skill said nothing about, beyond "a line in `runUpdate()`" — and both bugs here came from that gap. Adds a pre-flight question, an update column to the archetype table so each reference implementation shows how its releases actually travel, and a hard rule with the three questions to answer: does the client refresh the source itself, is anything pinned to something that stops moving, and do plugin files update or only the engine. |
| `src/__tests__/installCodexGemini.test.ts` | Asserts the `--ref main` pin and the upgrade args, extends the "no global mcp server" guard, and covers `readCodexMarketplaceRef` — a healthy `main` pin, the exact stale-branch case that caused this bug, and the null cases (local source, someone else's marketplace, missing file). |
| `src/__tests__/install.test.ts` | Covers the launcher's new step: present, version-gated, ahead of the engine handoff, and failure-tolerant. Since the launcher is a *string* tsc cannot typecheck, one test asserts every `mod.*` symbol it calls is really exported by `antigravity.ts` — so a rename cannot break auto-update silently. |

## Verification

Both paths were exercised for real, not just unit-tested.

- **Codex:** `updateCodex()` returned `{"method":"cli","refreshed":true,"reinstalled":true}` and the ChatGPT app moved from 1.8.3 to 1.10.0.
- **Antigravity:** ran the generated launcher against an isolated `HOME` with a stale plugin staged at 0.0.1. It logged `refreshed Antigravity skills/agents 0.0.1 -> 1.10.0`, rewrote `plugin.json`, staged 13 skills and 2 agents, removed a skill the old version had shipped (replace-not-merge held), and wrote both registries — `import_manifest.json` and the `plugins.cognigy-plugin.enabled` flag. A second run correctly did nothing.

480 tests pass, `tsc` clean, Prettier clean.

## Merge note

PR #27 (Antigravity) touches `docs/install/chatgpt-codex.md` and `README.md` too. Whichever lands second resolves a small conflict in the update sections.

## Test plan

Automated — CI runs tests and Prettier checks on every PR via `.github/workflows/pr.yml`.
