### PR TITLE
fix(endpoints): store the locale referenceId in localeId on endpoint creation

### DIFF
--- a/src/__tests__/manageWebchat.test.ts
+++ b/src/__tests__/manageWebchat.test.ts
@@ -35,6 +35,19 @@ describe("manage_webchat", () => {
     );
   });
 
+  // `/v2.0/locales` shape — endpoint.localeId must become the locale's
+  // referenceId, never its Mongo _id.
+  const mockLocales = {
+    items: [
+      {
+        _id: "60d5ec49f1a2c8b1a4e0f0aa",
+        referenceId: "8f2b1c14-1c62-4c1e-9d1f-1a2b3c4d5e6f",
+        primary: true,
+        projectReference: ID.project,
+      },
+    ],
+  };
+
   const mockEndpoint = {
     _id: ID.endpoint,
     name: "Webchat",
@@ -45,7 +58,7 @@ describe("manage_webchat", () => {
 
   it("creates new webchat endpoint when projectId and flowId provided", async () => {
     api.get
-      .mockResolvedValueOnce({ localeReference: "en-US" }) // flow locale
+      .mockResolvedValueOnce(mockLocales) // project locales
       .mockResolvedValueOnce(mockEndpoint); // re-fetch after create
     api.post.mockResolvedValueOnce({ _id: ID.endpoint });
 
@@ -86,7 +99,7 @@ describe("manage_webchat", () => {
 
   it("creates new endpoint even when existing webchat3 endpoints exist in project", async () => {
     api.get
-      .mockResolvedValueOnce({ localeReference: "en-US" }) // flow locale
+      .mockResolvedValueOnce(mockLocales) // project locales
       .mockResolvedValueOnce(mockEndpoint); // re-fetch after create
     api.post.mockResolvedValueOnce({ _id: ID.endpoint });
 
@@ -155,7 +168,7 @@ describe("manage_webchat", () => {
   });
 
   it("returns error when creation fails", async () => {
-    api.get.mockResolvedValueOnce({ localeReference: "en-US" });
+    api.get.mockResolvedValueOnce(mockLocales);
     api.post.mockRejectedValueOnce(new Error("Quota exceeded"));
 
     const result = await h.handleToolCall("manage_webchat", {
@@ -168,7 +181,7 @@ describe("manage_webchat", () => {
 
   it("handles settings patch failure on create (partial success)", async () => {
     api.get
-      .mockResolvedValueOnce({ localeReference: "en-US" }) // flow locale
+      .mockResolvedValueOnce(mockLocales) // project locales
       .mockResolvedValueOnce(mockEndpoint); // re-fetch after create
     api.post.mockResolvedValueOnce({ _id: ID.endpoint });
     api.patch.mockRejectedValueOnce(new Error("Settings validation failed"));
@@ -182,6 +195,31 @@ describe("manage_webchat", () => {
     expect(result.created).toBe(true);
     expect(result._hints).toBeDefined();
     expect(result._hints.warning).toContain("settings failed to apply");
+  });
+
+  // Regression: an endpoint created with an empty or Mongo-id localeId leaves
+  // "Open Demo Webchat" permanently disabled in the Cognigy UI.
+  it("creates the endpoint with the locale's referenceId as localeId", async () => {
+    api.get
+      .mockResolvedValueOnce(mockLocales) // project locales
+      .mockResolvedValueOnce(mockEndpoint); // re-fetch after create
+    api.post.mockResolvedValueOnce({ _id: ID.endpoint });
+
+    await h.handleToolCall("manage_webchat", {
+      projectId: ID.project,
+      flowId: "52a8fd93-4bb8-4b73-9b01-6350a7f364b8", // flow referenceId (UUID)
+    });
+
+    // The referenceId must never hit GET /v2.0/flows/{id} — it 400s there.
+    expect(api.get).not.toHaveBeenCalledWith(
+      "/v2.0/flows/52a8fd93-4bb8-4b73-9b01-6350a7f364b8",
+    );
+    expect(api.post).toHaveBeenCalledWith(
+      "/v2.0/endpoints",
+      expect.objectContaining({
+        localeId: mockLocales.items[0].referenceId,
+      }),
+    );
   });
 
   it("builds correct demoWebchatUrl and configUrl", async () => {

--- a/src/__tests__/manageWebchat.test.ts
+++ b/src/__tests__/manageWebchat.test.ts
@@ -222,6 +222,59 @@ describe("manage_webchat", () => {
     );
   });
 
+  it("ignores locale records without a referenceId", async () => {
+    api.get
+      .mockResolvedValueOnce({
+        items: [
+          {
+            _id: "60d5ec49f1a2c8b1a4e0f0ab",
+            primary: true,
+            projectReference: ID.project,
+          },
+          mockLocales.items[0],
+        ],
+      })
+      .mockResolvedValueOnce(mockEndpoint);
+    api.post.mockResolvedValueOnce({ _id: ID.endpoint });
+
+    await h.handleToolCall("manage_webchat", {
+      projectId: ID.project,
+      flowId: ID.flow,
+    });
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/v2.0/endpoints",
+      expect.objectContaining({
+        localeId: mockLocales.items[0].referenceId,
+      }),
+    );
+  });
+
+  it("omits localeId when no locale has a referenceId", async () => {
+    api.get
+      .mockResolvedValueOnce({
+        items: [
+          {
+            _id: "60d5ec49f1a2c8b1a4e0f0ab",
+            primary: true,
+            projectReference: ID.project,
+          },
+        ],
+      })
+      .mockResolvedValueOnce(mockEndpoint);
+    api.post.mockResolvedValueOnce({ _id: ID.endpoint });
+
+    await h.handleToolCall("manage_webchat", {
+      projectId: ID.project,
+      flowId: ID.flow,
+    });
+
+    expect(api.post).toHaveBeenCalledWith(
+      "/v2.0/endpoints",
+      expect.not.objectContaining({ localeId: expect.anything() }),
+    );
+  });
+
   it("builds correct demoWebchatUrl and configUrl", async () => {
     api.get
       .mockResolvedValueOnce(mockEndpoint) // full fetch

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -2749,7 +2749,16 @@ describe("ToolHandlers v2", () => {
       api.post.mockResolvedValueOnce(mockCreated);
       // GET after create
       api.get
-        .mockResolvedValueOnce({ localeReference: "loc-123" }) // flow lookup
+        .mockResolvedValueOnce({
+          items: [
+            {
+              _id: "60d5ec49f1a2c8b1a4e0f0aa",
+              referenceId: "loc-123",
+              primary: true,
+              projectReference: ID.project,
+            },
+          ],
+        }) // project locales
         .mockResolvedValueOnce(mockEndpoint) // after POST
         .mockResolvedValueOnce({ ...mockEndpoint, webrtcClient: true }); // after PATCH
       // PATCH to provision WebRTC
@@ -2902,7 +2911,16 @@ describe("ToolHandlers v2", () => {
 
       api.post.mockResolvedValueOnce(mockCreated);
       api.get
-        .mockResolvedValueOnce({ localeReference: "loc-123" }) // flow
+        .mockResolvedValueOnce({
+          items: [
+            {
+              _id: "60d5ec49f1a2c8b1a4e0f0aa",
+              referenceId: "loc-123",
+              primary: true,
+              projectReference: ID.project,
+            },
+          ],
+        }) // project locales
         .mockResolvedValueOnce(mockCreated); // after POST
       api.patch.mockRejectedValueOnce(new Error("WebRTC provision failed"));
 

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -596,15 +596,14 @@ async function resolveEndpointLocaleId(
     if (Array.isArray(items))
       locales = items.filter(
         (l: any) =>
-          !l?.projectReference || String(l.projectReference) === projectId,
+          (!l?.projectReference || String(l.projectReference) === projectId) &&
+          typeof l?.referenceId === "string" &&
+          l.referenceId.length > 0,
       );
   } catch {
     return undefined;
   }
   if (locales.length === 0) return undefined;
-
-  const refOf = (locale: any): string | undefined =>
-    locale?.referenceId ?? locale?._id ?? locale?.id;
 
   // Prefer the flow's locale — only worth the extra calls when the project
   // actually has more than one to choose from.
@@ -634,11 +633,11 @@ async function resolveEndpointLocaleId(
           String(l._id ?? l.id) === String(flowLocale) ||
           l.referenceId === flowLocale,
       );
-      if (match) return refOf(match);
+      if (match) return match.referenceId;
     }
   }
 
-  return refOf(locales.find((l: any) => l.primary) ?? locales[0]);
+  return (locales.find((l: any) => l.primary) ?? locales[0]).referenceId;
 }
 
 /**

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -572,6 +572,76 @@ async function resolveFlowForAgent(
 }
 
 /**
+ * Resolve the value to store in `endpoint.localeId` when creating an endpoint.
+ *
+ * `localeId` must be a locale *referenceId* (a UUID): the Endpoint Editor
+ * matches its locale dropdown on `referenceId`, and an endpoint with an empty
+ * or wrong `localeId` leaves "Open Demo Webchat" / "Open Demo Widget"
+ * permanently disabled (the editor never backfills an empty value).
+ */
+async function resolveEndpointLocaleId(
+  apiClient: CognigyApiClient,
+  projectId: string,
+  flowId?: string,
+): Promise<string | undefined> {
+  let locales: any[] = [];
+  try {
+    const resp: any = await apiClient.get("/v2.0/locales", {
+      params: { projectId, limit: 100 },
+    });
+    const items = resp?.items ?? resp;
+    // `/v2.0/locales` silently widens to EVERY project the key can see when
+    // `projectId` is not one of them (e.g. a snapshot id) — never pick a
+    // foreign project's locale.
+    if (Array.isArray(items))
+      locales = items.filter(
+        (l: any) =>
+          !l?.projectReference || String(l.projectReference) === projectId,
+      );
+  } catch {
+    return undefined;
+  }
+  if (locales.length === 0) return undefined;
+
+  const refOf = (locale: any): string | undefined =>
+    locale?.referenceId ?? locale?._id ?? locale?.id;
+
+  // Prefer the flow's locale — only worth the extra calls when the project
+  // actually has more than one to choose from.
+  if (flowId && locales.length > 1) {
+    let flow: any = null;
+    try {
+      if (/^[0-9a-f]{24}$/i.test(flowId)) {
+        flow = await apiClient.get(`/v2.0/flows/${flowId}`);
+      } else {
+        const flows: any = await apiClient.get("/v2.0/flows", {
+          params: { projectId, limit: 100 },
+        });
+        const items = flows?.items ?? flows;
+        const match = (Array.isArray(items) ? items : []).find(
+          (f: any) => f.referenceId === flowId,
+        );
+        const mongoId = match?._id ?? match?.id;
+        if (mongoId) flow = await apiClient.get(`/v2.0/flows/${mongoId}`);
+      }
+    } catch {
+      // fall through to the primary locale
+    }
+    const flowLocale = flow?.localeReference;
+    if (flowLocale) {
+      const match = locales.find(
+        (l: any) =>
+          String(l._id ?? l.id) === String(flowLocale) ||
+          l.referenceId === flowLocale,
+      );
+      if (match) return refOf(match);
+    }
+  }
+
+  return refOf(locales.find((l: any) => l.primary) ?? locales[0]);
+}
+
+/**
  * Thrown when the PLATFORM reported the task as failed/cancelled — i.e. the
  * operation itself definitively did not happen. Everything else that can go
  * wrong while polling (network blip, 5xx after the client's retries, a task
@@ -4049,15 +4119,11 @@ export class ToolHandlers {
         );
       }
 
-      let localeId: string | undefined;
-      try {
-        const flow: any = await this.apiClient.get(
-          `/v2.0/flows/${data.flowId}`,
-        );
-        localeId = flow?.localeReference;
-      } catch {
-        // Non-critical
-      }
+      const localeId = await resolveEndpointLocaleId(
+        this.apiClient,
+        data.projectId,
+        data.flowId,
+      );
 
       const createPayload: any = {
         projectId: data.projectId,
@@ -4289,29 +4355,12 @@ export class ToolHandlers {
         );
       }
 
-      // Resolve locale — try flow first, fall back to project's primary locale
-      let localeId: string | undefined;
-      try {
-        const flow: any = await this.apiClient.get(
-          `/v2.0/flows/${data.flowId}`,
-        );
-        localeId = flow?.localeReference;
-      } catch {
-        // Fall through to project locale
-      }
-      if (!localeId) {
-        try {
-          const locales: any = await this.apiClient.get("/v2.0/locales", {
-            params: { projectId: data.projectId },
-          });
-          const items = locales?.items ?? locales;
-          if (Array.isArray(items) && items.length > 0) {
-            localeId = items[0].referenceId ?? items[0]._id;
-          }
-        } catch {
-          // Non-critical — endpoint will be created without locale
-        }
-      }
+      // Resolve locale — the flow's when the project has several, else primary
+      const localeId = await resolveEndpointLocaleId(
+        this.apiClient,
+        data.projectId,
+        data.flowId,
+      );
 
       // Step 1: Create voiceGateway2 endpoint
       const createPayload: any = {


### PR DESCRIPTION
## Summary

- Webchat (and voice gateway) endpoints created by the plugin ended up with an empty `localeId`, which permanently disables **Open Demo Webchat** / **Open Demo Widget** in the Cognigy Endpoint Editor (the editor never backfills an empty locale)
- Root cause was twofold: the locale lookup called `GET /v2.0/flows/{flowId}` with the flow's referenceId (a UUID), which that route rejects with a 400 (`should be of format 'mongo-id'`) that was silently swallowed — and even on success, `flow.localeReference` is the locale's Mongo `_id`, while `endpoint.localeId` must be the locale's **referenceId**
- New shared `resolveEndpointLocaleId` helper resolves through `/v2.0/locales` (filtered to the project, since that route silently widens to all visible projects on an unknown projectId), prefers the flow's locale when the project has several, and returns the locale's referenceId

## Changes

| File / Component                    | Description                                                                                                          |
| ----------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
| `src/tools/handlers.ts`             | Added `resolveEndpointLocaleId`; both the `manage_webchat` and `manage_voice_gateway` create paths now use it        |
| `src/__tests__/manageWebchat.test.ts` | Mocks updated to the `/v2.0/locales` shape; regression test: a UUID flowId never hits `GET /v2.0/flows/{id}` and the created endpoint carries the locale's referenceId |
| `src/__tests__/tools.test.ts`       | Voice gateway create mocks updated to the `/v2.0/locales` shape                                                       |

## Test plan

Automated:

- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand` (563 passing)

Manual:

- Reproduced against a trial tenant: `GET /v2.0/flows/{referenceId}` 400s as described; a plugin-created webchat endpoint had `localeId: ""` and a disabled demo button
- Patching the endpoint's `localeId` to the project locale's referenceId enables the button

## Breaking changes / migration

- None. Endpoints already created with an empty `localeId` are not auto-healed — pick a Locale once in the Endpoint Editor (or PATCH `localeId`)

## Marketplace checklist

- [x] Versions left untouched — `package.json` and `plugin/.claude-plugin/plugin.json` are synced automatically by semantic-release on merge (`scripts/sync-plugin-version.mjs`); do not hand-edit either `version`
- [x] Tool count in `README.md` updated if the tool surface changed (unchanged)
- [x] `README.md` updated if user-facing behavior changed (no user-facing docs affected)
- [x] Tool annotations/descriptions reviewed if tool behavior changed (locale resolution is automatic; nothing new for the agent to pass)
- [x] `LICENSE` / marketplace metadata reviewed if submission requirements are affected (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)