### PR TITLE
fix(tools): validate and normalize tool parameter schemas

### DIFF
--- a/plugin/skills/tools-setup/SKILL.md
+++ b/plugin/skills/tools-setup/SKILL.md
@@ -19,6 +19,17 @@ Tools give an AI Agent capabilities beyond conversation — calling APIs, execut
 
 Rule of thumb: each tool in an agent flow should have a unique `toolId`. If you need more logic, parameters, validation, or HTTP calls for that tool, add them inside the same tool branch instead of creating another tool with the same `toolId`.
 
+## Parameter schema rules (config.parameters)
+
+`parameters` is a JSON Schema string that Cognigy passes VERBATIM to the LLM provider. create_tool / update_tool validate it and reject violations, because a broken schema either fails every conversation turn with a provider 400 (strict models) or is silently dropped (the tool is called with no arguments). The contract:
+
+- Top level: `{"type":"object","properties":{...},"required":[...]}` — `required` is mandatory (use `[]` if nothing is required).
+- EVERY property needs `"type"` AND `"description"`. Allowed types: `string`, `number`, `integer`, `boolean`, `object`, `array`, `null`.
+- `array` properties need `"items"`. Nested objects with `"properties"` also need their own `"required"`.
+- `"additionalProperties": false` is injected automatically at every object level.
+- Strict-mode models (OpenAI Responses API, e.g. gpt-5.x, where strict is forced on): list EVERY property key in `required`; make a parameter optional with a nullable type — `{"type":["string","null"],"description":"..."}`. Non-strict providers ignore this, so it is the safe default.
+- Nested object properties and `integer` are valid at runtime but not renderable by the Cognigy UI's graphical parameter builder — the node's Parameters section then shows the raw JSON editor. That is cosmetic; prefer flat schemas when you don't need nesting.
+
 ## Tool types (create_tool)
 
 ### tool — General-purpose tool with custom logic
@@ -31,7 +42,7 @@ name: "Fetch Weather",
 config: {
 toolId: "fetch_weather",
 description: "Fetches current weather for a city",
-parameters: '{"type":"object","properties":{"city":{"type":"string"}}}',
+parameters: '{"type":"object","properties":{"city":{"type":"string","description":"City to fetch the weather for"}},"required":["city"]}',
 toolResponseValue: "{{JSON.stringify(input.result)}}"
 }
 }
@@ -133,7 +144,7 @@ name: "Get Weather",
 config: {
 toolId: "get_weather",
 description: "Fetches current weather for a location",
-parameters: '{"type":"object","properties":{"city":{"type":"string"}}}',
+parameters: '{"type":"object","properties":{"city":{"type":"string","description":"City to fetch the weather for"}},"required":["city"]}',
 url: "https://api.weather.com/v1/current?q={{input.aiAgent.toolArgs.city}}",
 method: "GET",
 headers: { "X-Api-Key": "your-api-key" },
@@ -152,7 +163,7 @@ name: "Create Order",
 config: {
 toolId: "create_order",
 description: "Creates a new order in the order management system",
-parameters: '{"type":"object","properties":{"items":{"type":"array"},"customerId":{"type":"string"}}}',
+parameters: '{"type":"object","properties":{"items":{"type":"array","description":"Ordered items","items":{"type":"string","description":"SKU of one item"}},"customerId":{"type":"string","description":"Customer identifier"}},"required":["items","customerId"]}',
 url: "https://api.example.com/orders",
 method: "POST",
 headers: { "Authorization": "Bearer {{context.apiToken}}" },
@@ -214,7 +225,7 @@ create_tool {
   config: {
     toolId: "check_order_status",
     description: "Looks up the status of a customer order",
-    parameters: '{"type":"object","properties":{"orderId":{"type":"string"}}}'
+    parameters: '{"type":"object","properties":{"orderId":{"type":"string","description":"Order number to look up"}},"required":["orderId"]}'
   }
 }
 → returns toolNodeId: "abc123..."

--- a/src/__tests__/toolParameters.test.ts
+++ b/src/__tests__/toolParameters.test.ts
@@ -26,15 +26,28 @@ describe("normalizeToolParameters", () => {
     expect(parsed.type).toBe("object");
   });
 
-  it("preserves an explicit additionalProperties value", () => {
+  it("preserves an explicit additionalProperties: true but warns about strict models", () => {
     const raw = JSON.stringify({
       type: "object",
       properties: { a: { type: "string", description: "x" } },
       required: ["a"],
       additionalProperties: true,
     });
-    const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
-    expect(parsed.additionalProperties).toBe(true);
+    const { parameters, warnings } = normalizeToolParameters(raw);
+    expect(JSON.parse(parameters).additionalProperties).toBe(true);
+    expect(warnings.join(" ")).toMatch(/"additionalProperties": true/);
+  });
+
+  it("hard-fails on a non-boolean additionalProperties value", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { a: { type: "string", description: "x" } },
+      required: ["a"],
+      additionalProperties: "false",
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(
+      /"additionalProperties" must be the boolean false/,
+    );
   });
 
   it("hard-fails on unparseable JSON with a corrective message", () => {
@@ -57,6 +70,17 @@ describe("normalizeToolParameters", () => {
     });
     expect(() => normalizeToolParameters(raw)).toThrow(
       /confirmationCode: missing "description"/,
+    );
+  });
+
+  it("hard-fails on an empty type array", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { n: { type: [], description: "count" } },
+      required: ["n"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(
+      /"type" is an empty array/,
     );
   });
 
@@ -121,6 +145,34 @@ describe("normalizeToolParameters", () => {
     });
     const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
     expect(parsed.properties.address.additionalProperties).toBe(false);
+  });
+
+  it("infers type object for a nested property that only defines properties", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        address: {
+          description: "Postal address",
+          properties: {
+            street: { type: "string", description: "Street" },
+          },
+          required: ["street"],
+        },
+      },
+      required: ["address"],
+    });
+    const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
+    expect(parsed.properties.address.type).toBe("object");
+    expect(parsed.properties.address.additionalProperties).toBe(false);
+  });
+
+  it("hard-fails a property with neither type nor properties/enum/const/composition", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { a: { description: "no type at all" } },
+      required: ["a"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(/a: missing "type"/);
   });
 
   it("hard-fails a nested property missing a description", () => {

--- a/src/__tests__/toolParameters.test.ts
+++ b/src/__tests__/toolParameters.test.ts
@@ -1,0 +1,198 @@
+import { normalizeToolParameters } from "../tools/toolParameters.js";
+
+const valid = JSON.stringify({
+  type: "object",
+  properties: {
+    city: { type: "string", description: "City name" },
+  },
+  required: ["city"],
+});
+
+describe("normalizeToolParameters", () => {
+  it("accepts a valid schema and injects additionalProperties: false", () => {
+    const { parameters, warnings } = normalizeToolParameters(valid);
+    const parsed = JSON.parse(parameters);
+    expect(parsed.additionalProperties).toBe(false);
+    expect(parsed.properties.city.type).toBe("string");
+    expect(warnings).toEqual([]);
+  });
+
+  it("infers a missing top-level type when properties are present", () => {
+    const raw = JSON.stringify({
+      properties: { a: { type: "boolean", description: "A flag" } },
+      required: ["a"],
+    });
+    const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
+    expect(parsed.type).toBe("object");
+  });
+
+  it("preserves an explicit additionalProperties value", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { a: { type: "string", description: "x" } },
+      required: ["a"],
+      additionalProperties: true,
+    });
+    const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
+    expect(parsed.additionalProperties).toBe(true);
+  });
+
+  it("hard-fails on unparseable JSON with a corrective message", () => {
+    expect(() => normalizeToolParameters('{"type":"object",')).toThrow(
+      /not valid JSON/,
+    );
+  });
+
+  it("hard-fails when top-level type is not object", () => {
+    expect(() =>
+      normalizeToolParameters(JSON.stringify({ type: "string" })),
+    ).toThrow(/top-level "type" must be "object"/);
+  });
+
+  it("hard-fails when a property is missing its description", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { confirmationCode: { type: "string" } },
+      required: ["confirmationCode"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(
+      /confirmationCode: missing "description"/,
+    );
+  });
+
+  it("hard-fails on an unknown type value", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { n: { type: "int", description: "count" } },
+      required: ["n"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(/invalid type "int"/);
+  });
+
+  it("allows integer (valid JSON Schema, only unsupported by the UI builder)", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { n: { type: "integer", description: "A count" } },
+      required: ["n"],
+    });
+    expect(() => normalizeToolParameters(raw)).not.toThrow();
+  });
+
+  it("hard-fails when required is missing", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { a: { type: "string", description: "x" } },
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(/missing "required"/);
+  });
+
+  it("hard-fails when required names an unknown property", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { a: { type: "string", description: "x" } },
+      required: ["b"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(/not a key/);
+  });
+
+  it("hard-fails on array without items", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: { list: { type: "array", description: "Some list" } },
+      required: ["list"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(/requires "items"/);
+  });
+
+  it("allows nested object properties and validates them recursively", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        address: {
+          type: "object",
+          description: "Postal address",
+          properties: {
+            street: { type: "string", description: "Street" },
+          },
+          required: ["street"],
+        },
+      },
+      required: ["address"],
+    });
+    const parsed = JSON.parse(normalizeToolParameters(raw).parameters);
+    expect(parsed.properties.address.additionalProperties).toBe(false);
+  });
+
+  it("hard-fails a nested property missing a description", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        address: {
+          type: "object",
+          description: "Postal address",
+          properties: { street: { type: "string" } },
+          required: ["street"],
+        },
+      },
+      required: ["address"],
+    });
+    expect(() => normalizeToolParameters(raw)).toThrow(
+      /properties\.address\.properties\.street/,
+    );
+  });
+
+  it("aggregates multiple errors into one throw", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        a: { type: "string" },
+        b: { type: "array", description: "list" },
+      },
+      required: ["a", "b"],
+    });
+    let message = "";
+    try {
+      normalizeToolParameters(raw);
+    } catch (e: any) {
+      message = e.message;
+    }
+    expect(message).toMatch(/a: missing "description"/);
+    expect(message).toMatch(/b: type "array" requires "items"/);
+  });
+
+  it("warns (not fails) when required does not list every key", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        a: { type: "string", description: "x" },
+        b: { type: "string", description: "y" },
+      },
+      required: ["a"],
+    });
+    const { warnings } = normalizeToolParameters(raw);
+    expect(warnings.join(" ")).toMatch(/strict/i);
+  });
+
+  it("warns on unknown keywords that strict providers may reject", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        a: { type: "string", description: "x", format: "date-time" },
+      },
+      required: ["a"],
+    });
+    const { warnings } = normalizeToolParameters(raw);
+    expect(warnings.join(" ")).toMatch(/"format"/);
+  });
+
+  it("accepts nullable union types for optional parameters", () => {
+    const raw = JSON.stringify({
+      type: "object",
+      properties: {
+        note: { type: ["string", "null"], description: "Optional note" },
+      },
+      required: ["note"],
+    });
+    expect(normalizeToolParameters(raw).warnings).toEqual([]);
+  });
+});

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -1653,7 +1653,8 @@ describe("ToolHandlers v2", () => {
         config: {
           toolId: "my_tool",
           description: "desc",
-          parameters: '{"type":"object","properties":{"q":{"type":"string"}}}',
+          parameters:
+            '{"type":"object","properties":{"q":{"type":"string","description":"Query"}},"required":["q"]}',
         },
       });
 

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -595,7 +595,7 @@ After creating, use talk_to_agent to test.`,
             parameters: {
               type: "string",
               description:
-                "JSON Schema string defining tool parameters (tool, http)",
+                'JSON Schema string defining tool parameters (tool, http). Contract: top level {"type":"object","properties":{...},"required":[...]} — "required" is mandatory (use [] if none); EVERY property needs "type" AND "description"; allowed types: string, number, integer, boolean, object, array, null; "array" needs "items"; nested objects with "properties" also need "required". For strict-mode models (OpenAI Responses API, e.g. gpt-5.x) list EVERY key in "required" and mark optional params nullable, e.g. {"type":["string","null"]}. "additionalProperties":false is added automatically. Example: {"type":"object","properties":{"city":{"type":"string","description":"City name"}},"required":["city"]}',
             },
             knowledgeStoreId: {
               type: "string",
@@ -717,7 +717,7 @@ After creating, use talk_to_agent to test.`,
             parameters: {
               type: "string",
               description:
-                "JSON Schema string defining tool parameters (tool, http)",
+                'JSON Schema string defining tool parameters (tool, http). Contract: top level {"type":"object","properties":{...},"required":[...]} — "required" is mandatory (use [] if none); EVERY property needs "type" AND "description"; allowed types: string, number, integer, boolean, object, array, null; "array" needs "items"; nested objects with "properties" also need "required". For strict-mode models (OpenAI Responses API, e.g. gpt-5.x) list EVERY key in "required" and mark optional params nullable, e.g. {"type":["string","null"]}. "additionalProperties":false is added automatically. Example: {"type":"object","properties":{"city":{"type":"string","description":"City name"}},"required":["city"]}',
             },
             knowledgeStoreId: {
               type: "string",

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -23,6 +23,7 @@ import {
   withHints,
 } from "./filters.js";
 import { buildWebchatSettings, deepMerge } from "./webchatSettings.js";
+import { normalizeToolParameters } from "./toolParameters.js";
 import { getNodeEntry, supportedNodeTypes } from "./nodeRegistry.js";
 import {
   evaluateChecks,
@@ -3358,13 +3359,16 @@ export class ToolHandlers {
     if (!mapping) throw new Error(`Unknown toolType: ${data.toolType}`);
 
     const nodeConfig: any = {};
+    let parameterWarnings: string[] = [];
     switch (data.toolType) {
       case "tool":
         if (cfg.toolId) nodeConfig.toolId = cfg.toolId;
         if (cfg.description) nodeConfig.description = cfg.description;
         if (cfg.parameters) {
+          const normalized = normalizeToolParameters(cfg.parameters);
           nodeConfig.useParameters = true;
-          nodeConfig.parameters = cfg.parameters;
+          nodeConfig.parameters = normalized.parameters;
+          parameterWarnings = normalized.warnings;
         }
         break;
       case "knowledge":
@@ -3388,8 +3392,10 @@ export class ToolHandlers {
         if (cfg.toolId) nodeConfig.toolId = cfg.toolId;
         if (cfg.description) nodeConfig.description = cfg.description;
         if (cfg.parameters) {
+          const normalized = normalizeToolParameters(cfg.parameters);
           nodeConfig.useParameters = true;
-          nodeConfig.parameters = cfg.parameters;
+          nodeConfig.parameters = normalized.parameters;
+          parameterWarnings = normalized.warnings;
         }
         break;
     }
@@ -3440,12 +3446,15 @@ export class ToolHandlers {
           if (resolveNodeId) createdNodeIds.push(resolveNodeId);
         }
 
-        return {
+        const created = {
           toolId: toolNodeId,
           name: data.name,
           toolType: data.toolType,
           ...(resolveNodeId ? { resolveNodeId } : {}),
         };
+        return parameterWarnings.length > 0
+          ? withHints(created, { warning: parameterWarnings.join(" ") })
+          : created;
       } catch (error: any) {
         const rolledBack: string[] = [];
         const rollbackFailed: string[] = [];
@@ -3571,7 +3580,7 @@ export class ToolHandlers {
         if (postProcessNodeId) createdNodeIds.push(postProcessNodeId);
       }
 
-      return {
+      const createdHttp = {
         toolId: toolNodeId,
         name: data.name,
         toolType: "http",
@@ -3582,6 +3591,9 @@ export class ToolHandlers {
           resolveNodeId,
         },
       };
+      return parameterWarnings.length > 0
+        ? withHints(createdHttp, { warning: parameterWarnings.join(" ") })
+        : createdHttp;
     } catch (error: any) {
       const rolledBack: string[] = [];
       const rollbackFailed: string[] = [];
@@ -3645,6 +3657,7 @@ export class ToolHandlers {
 
     // Step 1: Update the tool node itself (label and/or tool-node config)
     const patchPayload: any = {};
+    let parameterWarnings: string[] = [];
     if (data.name) patchPayload.label = data.name;
 
     if (cfg) {
@@ -3654,8 +3667,10 @@ export class ToolHandlers {
         if (cfg.toolId) nodeConfig.toolId = cfg.toolId;
         if (cfg.description) nodeConfig.description = cfg.description;
         if (cfg.parameters) {
+          const normalized = normalizeToolParameters(cfg.parameters);
           nodeConfig.useParameters = true;
-          nodeConfig.parameters = cfg.parameters;
+          nodeConfig.parameters = normalized.parameters;
+          parameterWarnings = normalized.warnings;
         }
       }
       if (toolType === "knowledge") {
@@ -3842,13 +3857,18 @@ export class ToolHandlers {
 
     if (skippedUpdates.length > 0) {
       return withHints(response, {
-        warning: `Some updates were skipped: ${skippedUpdates.join("; ")}`,
+        warning: [
+          `Some updates were skipped: ${skippedUpdates.join("; ")}`,
+          ...parameterWarnings,
+        ].join(" "),
         action:
           "Child nodes may not exist yet. Use create_tool with http type to create the full node tree, or verify the tool structure.",
       });
     }
 
-    return response;
+    return parameterWarnings.length > 0
+      ? withHints(response, { warning: parameterWarnings.join(" ") })
+      : response;
   }
 
   // =========================================================================

--- a/src/tools/toolParameters.ts
+++ b/src/tools/toolParameters.ts
@@ -19,7 +19,8 @@
  *
  * Hard errors are aggregated and thrown so the calling LLM can correct the
  * whole schema in one retry. Mechanically safe fixes are applied silently:
- * a missing top-level `type` is inferred as "object", and
+ * a missing `type` is inferred as "object" wherever `properties` is defined
+ * (strict providers require an explicit type on every level), and
  * `additionalProperties: false` is injected wherever an object level defines
  * `properties` without it.
  */
@@ -108,10 +109,19 @@ function validateSchema(
     ctx.errors.push(`${path}: "description" must be a string`);
   }
 
+  if (schema.type === undefined && isPlainObject(schema.properties)) {
+    schema.type = "object"; // safe inference, same as at the top level
+  }
+
   // type may be a string or an array of strings (e.g. ["string","null"])
   const types: string[] = [];
   if (schema.type !== undefined) {
     const list = Array.isArray(schema.type) ? schema.type : [schema.type];
+    if (Array.isArray(schema.type) && list.length === 0) {
+      ctx.errors.push(
+        `${path}: "type" is an empty array — declare at least one of ${[...ALLOWED_TYPES].join(", ")}`,
+      );
+    }
     for (const t of list) {
       if (typeof t !== "string" || !ALLOWED_TYPES.has(t)) {
         ctx.errors.push(
@@ -187,6 +197,14 @@ function validateSchema(
         // Responses-API models (strict by default) demand it.
         if (schema.additionalProperties === undefined) {
           schema.additionalProperties = false;
+        } else if (typeof schema.additionalProperties !== "boolean") {
+          ctx.errors.push(
+            `${path}: "additionalProperties" must be the boolean false (got ${JSON.stringify(schema.additionalProperties)})`,
+          );
+        } else if (schema.additionalProperties === true) {
+          ctx.warnings.push(
+            `${path}: "additionalProperties": true — strict-mode models (OpenAI Responses API, e.g. gpt-5.x) reject any value other than false; set it to false and declare every parameter in "properties" if the target model is strict`,
+          );
         }
       }
     } else {
@@ -268,7 +286,7 @@ export function normalizeToolParameters(raw: string): NormalizedToolParameters {
     throw new Error(
       `Invalid tool parameters schema:\n- ${ctx.errors.join("\n- ")}\n` +
         `Fix the schema and retry. Contract: top level is {"type":"object","properties":{...},"required":[...]}; ` +
-        `every entry in a "properties" map needs "type" and "description"; allowed types: ${[...ALLOWED_TYPES].join(", ")}; ` +
+        `every entry in a "properties" map needs "description" and a "type" (inferred as "object" when it defines "properties"; optional only when "enum", "const", or anyOf/oneOf/allOf is used); allowed types: ${[...ALLOWED_TYPES].join(", ")}; ` +
         `"array" needs "items"; any level defining "properties" also needs a "required" array. ` +
         `Strict-mode models (OpenAI Responses API, e.g. gpt-5.x) additionally require every property key listed in "required" — make a parameter optional with a nullable type such as {"type":["string","null"]}.`,
     );

--- a/src/tools/toolParameters.ts
+++ b/src/tools/toolParameters.ts
@@ -1,0 +1,298 @@
+/**
+ * Validation + normalization for AI Agent Tool `parameters` (a JSON Schema
+ * authored by the calling LLM and stored as a string on the tool node).
+ *
+ * The Cognigy runtime passes this schema VERBATIM to the LLM provider
+ * (shared/charts/.../createToolDefinitions.ts) and the backend only checks
+ * "string, ≤100k chars" — an unparseable schema is silently dropped at
+ * runtime (the tool is sent with no parameters at all), and a schema that
+ * violates a strict provider's subset fails every conversation turn with a
+ * 400. OpenAI Responses-API models (gpt-5.x) are strict by default: they
+ * require `additionalProperties: false` on every object level and every
+ * property key listed in `required`.
+ *
+ * We therefore validate the contract that actually breaks at runtime — NOT
+ * the stricter subset of the Cognigy UI's graphical parameter builder
+ * (services/service-ui/.../toolParameterSchema.ts). Constructs the builder
+ * can't render (nested object properties, "integer") are valid here; the UI
+ * simply falls back to its raw JSON editor for them.
+ *
+ * Hard errors are aggregated and thrown so the calling LLM can correct the
+ * whole schema in one retry. Mechanically safe fixes are applied silently:
+ * a missing top-level `type` is inferred as "object", and
+ * `additionalProperties: false` is injected wherever an object level defines
+ * `properties` without it.
+ */
+
+const ALLOWED_TYPES = new Set([
+  "string",
+  "number",
+  "integer",
+  "boolean",
+  "object",
+  "array",
+  "null",
+]);
+
+/** Keywords we understand; anything else earns a strict-provider warning. */
+const KNOWN_KEYWORDS = new Set([
+  "type",
+  "description",
+  "properties",
+  "required",
+  "additionalProperties",
+  "items",
+  "enum",
+  "const",
+  "anyOf",
+  "oneOf",
+  "allOf",
+  "title",
+]);
+
+/** Backend limit: services/service-resources validation/schemas.ts caps the field at 100k chars. */
+const MAX_LENGTH = 100_000;
+
+export interface NormalizedToolParameters {
+  /** Normalized JSON string to store on the node. */
+  parameters: string;
+  /** Non-fatal notes to surface to the calling LLM via _hints. */
+  warnings: string[];
+}
+
+interface Ctx {
+  errors: string[];
+  warnings: string[];
+  /** paths whose `required` array does not list every property key */
+  incompleteRequired: string[];
+  /** unknown keywords seen, as "keyword at path" */
+  unknownKeywords: string[];
+}
+
+function isPlainObject(v: unknown): v is Record<string, any> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+/**
+ * Validate one schema node in place (normalizations mutate the parsed tree).
+ * `requireDescription` is true for entries of a `properties` map — those are
+ * what the model reads to decide how to call the tool.
+ */
+function validateSchema(
+  schema: any,
+  path: string,
+  requireDescription: boolean,
+  ctx: Ctx,
+): void {
+  if (!isPlainObject(schema)) {
+    ctx.errors.push(`${path}: must be an object (a JSON Schema definition)`);
+    return;
+  }
+
+  for (const key of Object.keys(schema)) {
+    if (!KNOWN_KEYWORDS.has(key)) {
+      ctx.unknownKeywords.push(`"${key}" at ${path}`);
+    }
+  }
+
+  if (requireDescription) {
+    if (typeof schema.description !== "string" || !schema.description.trim()) {
+      ctx.errors.push(
+        `${path}: missing "description" — every parameter needs a description string so the model knows what to pass`,
+      );
+    }
+  } else if (
+    schema.description !== undefined &&
+    typeof schema.description !== "string"
+  ) {
+    ctx.errors.push(`${path}: "description" must be a string`);
+  }
+
+  // type may be a string or an array of strings (e.g. ["string","null"])
+  const types: string[] = [];
+  if (schema.type !== undefined) {
+    const list = Array.isArray(schema.type) ? schema.type : [schema.type];
+    for (const t of list) {
+      if (typeof t !== "string" || !ALLOWED_TYPES.has(t)) {
+        ctx.errors.push(
+          `${path}: invalid type ${JSON.stringify(t)} — allowed types are ${[...ALLOWED_TYPES].join(", ")}`,
+        );
+      } else {
+        types.push(t);
+      }
+    }
+  }
+
+  const hasComposition = ["anyOf", "oneOf", "allOf"].some(
+    (k) => schema[k] !== undefined,
+  );
+  if (
+    schema.type === undefined &&
+    schema.properties === undefined &&
+    schema.enum === undefined &&
+    schema.const === undefined &&
+    !hasComposition
+  ) {
+    ctx.errors.push(
+      `${path}: missing "type" — declare one of ${[...ALLOWED_TYPES].join(", ")}`,
+    );
+  }
+
+  if (schema.enum !== undefined && !Array.isArray(schema.enum)) {
+    ctx.errors.push(`${path}: "enum" must be an array of allowed values`);
+  }
+
+  for (const comboKey of ["anyOf", "oneOf", "allOf"]) {
+    const combo = schema[comboKey];
+    if (combo === undefined) continue;
+    if (!Array.isArray(combo)) {
+      ctx.errors.push(`${path}: "${comboKey}" must be an array of schemas`);
+      continue;
+    }
+    combo.forEach((sub: any, i: number) =>
+      validateSchema(sub, `${path}.${comboKey}[${i}]`, false, ctx),
+    );
+  }
+
+  // Object semantics — nested properties are fine at runtime (the Cognigy
+  // graphical builder just falls back to its JSON editor for them).
+  if (schema.properties !== undefined || types.includes("object")) {
+    if (schema.properties !== undefined) {
+      if (!isPlainObject(schema.properties)) {
+        ctx.errors.push(`${path}: "properties" must be an object map`);
+      } else {
+        for (const [name, sub] of Object.entries(schema.properties)) {
+          validateSchema(sub, `${path}.properties.${name}`, true, ctx);
+        }
+
+        if (!Array.isArray(schema.required)) {
+          ctx.errors.push(
+            `${path}: missing "required" — list the mandatory property names as an array (use [] if none)`,
+          );
+        } else {
+          const keys = new Set(Object.keys(schema.properties));
+          for (const r of schema.required) {
+            if (typeof r !== "string" || !keys.has(r)) {
+              ctx.errors.push(
+                `${path}: "required" lists ${JSON.stringify(r)}, which is not a key of "properties"`,
+              );
+            }
+          }
+          if ([...keys].some((k) => !schema.required.includes(k))) {
+            ctx.incompleteRequired.push(path);
+          }
+        }
+
+        // Strict-proofing: providers all accept this, and OpenAI's
+        // Responses-API models (strict by default) demand it.
+        if (schema.additionalProperties === undefined) {
+          schema.additionalProperties = false;
+        }
+      }
+    } else {
+      ctx.warnings.push(
+        `${path}: "object" without "properties" — strict-mode models (OpenAI Responses API, e.g. gpt-5.x) reject free-form objects; define its properties if the target model is strict`,
+      );
+    }
+  }
+
+  // Array semantics
+  if (types.includes("array")) {
+    if (schema.items === undefined) {
+      ctx.errors.push(
+        `${path}: type "array" requires "items" describing the element schema`,
+      );
+    } else if (Array.isArray(schema.items)) {
+      schema.items.forEach((sub: any, i: number) =>
+        validateSchema(sub, `${path}.items[${i}]`, false, ctx),
+      );
+    } else {
+      validateSchema(schema.items, `${path}.items`, false, ctx);
+    }
+  } else if (schema.items !== undefined && !types.includes("array")) {
+    ctx.warnings.push(
+      `${path}: has "items" but type is not "array" — "items" will be ignored`,
+    );
+  }
+}
+
+/**
+ * Parse, validate, and normalize a tool `parameters` JSON string.
+ * Throws an Error aggregating every problem so the caller (an LLM) can fix
+ * the schema in a single retry. Returns the normalized JSON string plus
+ * non-fatal warnings.
+ */
+export function normalizeToolParameters(raw: string): NormalizedToolParameters {
+  let root: any;
+  try {
+    root = JSON.parse(raw);
+  } catch (e: any) {
+    throw new Error(
+      `config.parameters is not valid JSON (${e.message}). ` +
+        `Cognigy stores it as-is and silently drops unparseable schemas at runtime — the tool would be sent to the LLM with NO parameters. ` +
+        `Provide a JSON Schema string like: {"type":"object","properties":{"city":{"type":"string","description":"City name"}},"required":["city"]}`,
+    );
+  }
+
+  const ctx: Ctx = {
+    errors: [],
+    warnings: [],
+    incompleteRequired: [],
+    unknownKeywords: [],
+  };
+
+  if (!isPlainObject(root)) {
+    ctx.errors.push(
+      `parameters: must be a JSON object of the form {"type":"object","properties":{...},"required":[...]}`,
+    );
+  } else {
+    if (root.type === undefined && isPlainObject(root.properties)) {
+      root.type = "object"; // safe inference
+    }
+    if (root.type !== "object") {
+      ctx.errors.push(
+        `parameters: top-level "type" must be "object" (got ${JSON.stringify(root.type)})`,
+      );
+    }
+    if (!isPlainObject(root.properties)) {
+      ctx.errors.push(
+        `parameters: top-level "properties" object is required — a map of parameter name to schema`,
+      );
+    }
+    if (ctx.errors.length === 0) {
+      validateSchema(root, "parameters", false, ctx);
+    }
+  }
+
+  if (ctx.errors.length > 0) {
+    throw new Error(
+      `Invalid tool parameters schema:\n- ${ctx.errors.join("\n- ")}\n` +
+        `Fix the schema and retry. Contract: top level is {"type":"object","properties":{...},"required":[...]}; ` +
+        `every entry in a "properties" map needs "type" and "description"; allowed types: ${[...ALLOWED_TYPES].join(", ")}; ` +
+        `"array" needs "items"; any level defining "properties" also needs a "required" array. ` +
+        `Strict-mode models (OpenAI Responses API, e.g. gpt-5.x) additionally require every property key listed in "required" — make a parameter optional with a nullable type such as {"type":["string","null"]}.`,
+    );
+  }
+
+  const warnings = [...ctx.warnings];
+  if (ctx.incompleteRequired.length > 0) {
+    warnings.push(
+      `Not every property key is listed in "required" (at ${ctx.incompleteRequired.join(", ")}). ` +
+        `Strict-mode models (OpenAI Responses API, e.g. gpt-5.x) reject such schemas with a 400 — list every key in "required" and mark optional parameters with a nullable type like {"type":["string","null"]} if this agent may use a strict model.`,
+    );
+  }
+  if (ctx.unknownKeywords.length > 0) {
+    warnings.push(
+      `Schema uses keyword(s) ${ctx.unknownKeywords.join(", ")} that strict-mode OpenAI models may reject; they are passed through unchanged.`,
+    );
+  }
+
+  const normalized = JSON.stringify(root);
+  if (normalized.length > MAX_LENGTH) {
+    throw new Error(
+      `config.parameters exceeds Cognigy's ${MAX_LENGTH}-character limit for tool parameter schemas (got ${normalized.length}). Simplify the schema.`,
+    );
+  }
+
+  return { parameters: normalized, warnings };
+}


### PR DESCRIPTION
## Summary

- Validate and normalize `config.parameters` (the LLM-authored JSON Schema) in `create_tool` / `update_tool` instead of passing it through as an unvalidated string
- Hard-fail with one aggregated, path-specific error message so the calling LLM can correct the whole schema in a single retry; inject `additionalProperties: false` at every object level and surface strict-mode hazards as `_hints` warnings
- Document the schema contract in the tool definitions and fix the tools-setup skill examples, which previously demonstrated invalid schemas

## Why

Cognigy forwards the tool `parameters` schema **verbatim** to the LLM provider, and on OpenAI Responses-API models (gpt-5.x) the converter forces `strict: true` regardless of the node's `useStrict` toggle. A schema without `additionalProperties: false` or a complete `required` list then fails **every conversation turn** with a provider 400 (observed live: `Invalid schema for function 'search_trips': 'additionalProperties' is required to be supplied and to be false`). Unparseable JSON is even worse: the runtime silently drops it and sends the tool with no parameters at all.

The validator deliberately mirrors the **runtime/provider contract**, not the stricter subset of the Cognigy UI's graphical parameter builder (`toolParameterSchema.ts`, which is UI-only) — nested object `properties` and `integer` stay allowed; the UI just falls back to its raw JSON editor for them.

Rules enforced (hard error): parseable JSON; top level `{"type":"object","properties":{...},"required":[...]}`; every property has `type` + `description`; allowed types `string, number, integer, boolean, object, array, null`; `array` has `items`; any level defining `properties` has `required`; ≤100k chars (backend limit). Normalized silently: missing top-level `type` inferred, `additionalProperties: false` injected. Warned via `_hints`: `required` not covering all keys (strict models reject this — optional params should be nullable, e.g. `{"type":["string","null"]}`), unknown keywords, free-form objects.

## Changes

| File / Component | Description |
| ---------------- | ----------- |
| `src/tools/toolParameters.ts` | New `normalizeToolParameters()` — parse, validate, normalize; aggregated corrective errors; warnings for strict-mode hazards |
| `src/tools/handlers.ts` | Wired into all three `parameters` sites (create tool, create http, update); warnings attached to success responses via `withHints` |
| `src/tools/definitions.ts` | `parameters` descriptions in `create_tool` / `update_tool` now spell out the contract with an example |
| `plugin/skills/tools-setup/SKILL.md` | New "Parameter schema rules" section; all four examples fixed (they taught the invalid pattern) |
| `src/__tests__/toolParameters.test.ts` | 16 tests covering errors, normalizations, and warnings |
| `src/__tests__/tools.test.ts` | Existing fixture updated to a valid schema |

## Test plan

Automated:

- `npx tsc -p tsconfig.json --noEmit`
- `npm test -- --runInBand` (603 passed, incl. 16 new)

Manual:

- Repaired the three broken tools on the live "Mira — Travel Concierge" agent (Meridian (Test)) with schemas matching the new contract; the previously failing turn against a strict OpenAI model now answers, and a trip request successfully invokes `search_trips`

## Breaking changes / migration

- `create_tool` / `update_tool` now reject parameter schemas they previously accepted (missing `required`, missing per-property `description`/`type`, `array` without `items`, invalid JSON). This is intentional: every rejected schema was either already failing at conversation time on strict providers or degrading tool-calling quality. The error message tells the calling LLM exactly how to fix the schema.

## Marketplace checklist

- [x] Versions left untouched — `package.json` and `plugin/.claude-plugin/plugin.json` are synced automatically by semantic-release on merge (`scripts/sync-plugin-version.mjs`); do not hand-edit either `version`
- [x] Tool count in `README.md` updated if the tool surface changed (unchanged — no new tool)
- [x] `README.md` updated if user-facing behavior changed (behavior change is LLM-facing, documented in definitions + skill)
- [x] Tool annotations/descriptions reviewed if tool behavior changed
- [x] `LICENSE` / marketplace metadata reviewed if submission requirements are affected (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)