### PR TITLE
fix(tools): hold all concurrent first-change calls behind the backup gate

### DIFF
--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -4336,6 +4336,60 @@ describe("manage_snapshots", () => {
       expect(second.error).toBeUndefined();
     });
 
+    it("holds ALL concurrent distinct mutations to the same project", async () => {
+      // A client may issue several mutating calls in one parallel batch. Only
+      // releasing after the first hold would let the rest mutate the project
+      // before the backup offer was ever answered.
+      const [first, second] = await Promise.all([
+        h.handleToolCall("manage_settings", {
+          operation: "set_knowledge_ai",
+          projectId: ID.project,
+          knowledgeSearchModelId: "m1",
+        }),
+        h.handleToolCall("manage_settings", {
+          operation: "set_knowledge_ai",
+          projectId: ID.project,
+          knowledgeSearchModelId: "m2",
+        }),
+      ]);
+
+      expect(first.error).toBe("backup_not_offered");
+      expect(second.error).toBe("backup_not_offered");
+      expect(api.patch).not.toHaveBeenCalled();
+      expect(api.post).not.toHaveBeenCalled();
+
+      // Once the offer is answered, the held calls run on retry.
+      await h.handleToolCall("manage_snapshots", {
+        operation: "decline",
+        projectId: ID.project,
+      });
+      api.get.mockResolvedValue({ _id: ID.project } as any);
+      api.patch.mockResolvedValue({ _id: ID.project } as any);
+      const retry = await h.handleToolCall("manage_settings", {
+        operation: "set_knowledge_ai",
+        projectId: ID.project,
+        knowledgeSearchModelId: "m2",
+      });
+      expect(retry.error).not.toBe("backup_not_offered");
+    });
+
+    it("holds concurrent distinct mutations even when the project is unknown", async () => {
+      const [first, second] = await Promise.all([
+        h.handleToolCall("update_ai_agent", {
+          aiAgentId: ID.agent,
+          description: "a",
+        }),
+        h.handleToolCall("update_ai_agent", {
+          aiAgentId: ID.agent,
+          description: "b",
+        }),
+      ]);
+
+      expect(first.error).toBe("backup_not_offered");
+      expect(second.error).toBe("backup_not_offered");
+      expect(api.patch).not.toHaveBeenCalled();
+    });
+
     it("does not hold create_ai_agent itself", () => {
       expect(
         (ToolHandlers as any).isBackupWorthyCall("create_ai_agent", {}),

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -4388,6 +4388,25 @@ describe("manage_snapshots", () => {
       expect(first.error).toBe("backup_not_offered");
       expect(second.error).toBe("backup_not_offered");
       expect(api.patch).not.toHaveBeenCalled();
+
+      // Any answer, anywhere, releases the unknown-project fallback: a retry
+      // after decline proceeds instead of being held again.
+      await h.handleToolCall("manage_snapshots", {
+        operation: "decline",
+        projectId: ID.project,
+      });
+      api.get.mockResolvedValue({
+        _id: ID.agent,
+        name: "Agent",
+        flowId: ID.flow,
+      } as any);
+      api.patch.mockResolvedValue({ _id: ID.agent, name: "Agent" } as any);
+      const retry = await h.handleToolCall("update_ai_agent", {
+        aiAgentId: ID.agent,
+        description: "b",
+      });
+      expect(retry.error).toBeUndefined();
+      expect(api.patch).toHaveBeenCalled();
     });
 
     it("does not hold create_ai_agent itself", () => {

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -788,12 +788,23 @@ export class ToolHandlers {
   //
   // The answer is kept PER PROJECT: a user who declines a backup on a sandbox
   // must still be asked before the first change to a production project. Only
-  // the anti-deadlock trip is global for calls whose project cannot be
-  // determined (see backupGateFor).
+  // the anti-deadlock hold falls back to session-wide state for calls whose
+  // project cannot be determined (see backupGateFor).
   private readonly snapshotCreatedForProject = new Set<string>();
   private readonly backupDeclinedForProject = new Set<string>();
-  private readonly backupGateHeldForProject = new Set<string>();
-  private backupGateTripped = false;
+  /**
+   * Call signatures (tool + args) the gate has already held, per project. The
+   * anti-deadlock release is keyed on the SIGNATURE, not the project: a client
+   * that ignores the offer and retries the same call proceeds, but a client
+   * that issues several DIFFERENT mutations in parallel has each of them held
+   * until the offer is answered — otherwise only the first of a concurrent
+   * burst would be held and the rest would mutate the project unprotected.
+   */
+  private readonly backupGateHeldCallsForProject = new Map<
+    string,
+    Set<string>
+  >();
+  private readonly backupGateHeldCallsWithoutProject = new Set<string>();
   /**
    * projectId of resources seen this session, so the gate can tell which
    * project a call like update_ai_agent { aiAgentId } belongs to WITHOUT
@@ -5382,6 +5393,11 @@ export class ToolHandlers {
 
   private backupGateFor(toolName: string, args: any): any | null {
     const projectId = this.projectForCall(args);
+    // Held calls are remembered by signature so a retry of a call that was
+    // already held proceeds (anti-deadlock), while a concurrent DIFFERENT
+    // mutation is held too. Marking happens synchronously, before any await,
+    // so parallel calls in one client message cannot slip past each other.
+    const signature = `${toolName} ${JSON.stringify(args ?? null)}`;
 
     if (projectId) {
       // Answered for THIS project? Let it through. An answer given for another
@@ -5392,22 +5408,25 @@ export class ToolHandlers {
       ) {
         return null;
       }
-      // Anti-deadlock: hold once per project. A client that ignores the offer
-      // and retries proceeds rather than looping forever.
-      if (this.backupGateHeldForProject.has(projectId)) return null;
-      this.backupGateHeldForProject.add(projectId);
+      // Anti-deadlock: hold each distinct call once. A client that ignores
+      // the offer and retries proceeds rather than looping forever.
+      const held = this.backupGateHeldCallsForProject.get(projectId);
+      if (held?.has(signature)) return null;
+      if (held) held.add(signature);
+      else
+        this.backupGateHeldCallsForProject.set(projectId, new Set([signature]));
     } else {
       // Project unknown (e.g. delete_resource on a resource never read this
       // session). Fall back to session-wide state: any answer, anywhere, and
-      // one global hold.
+      // one hold per distinct call.
       if (
         this.snapshotCreatedForProject.size ||
         this.backupDeclinedForProject.size ||
-        this.backupGateTripped
+        this.backupGateHeldCallsWithoutProject.has(signature)
       ) {
         return null;
       }
-      this.backupGateTripped = true;
+      this.backupGateHeldCallsWithoutProject.add(signature);
     }
 
     return withHints(

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -799,6 +799,8 @@ export class ToolHandlers {
    * that issues several DIFFERENT mutations in parallel has each of them held
    * until the offer is answered — otherwise only the first of a concurrent
    * burst would be held and the rest would mutate the project unprotected.
+   * Known limitation: an IDENTICAL duplicate issued concurrently is
+   * indistinguishable from a retry by signature and is let through.
    */
   private readonly backupGateHeldCallsForProject = new Map<
     string,
@@ -5391,6 +5393,17 @@ export class ToolHandlers {
     return null;
   }
 
+  /**
+   * Once the offer is answered for a project, the answered-check in
+   * backupGateFor short-circuits before the held sets are consulted — so the
+   * accumulated signatures are dead weight and can be dropped. The
+   * without-project set is likewise never consulted once any answer exists.
+   */
+  private releaseBackupGateHolds(projectId: string): void {
+    this.backupGateHeldCallsForProject.delete(projectId);
+    this.backupGateHeldCallsWithoutProject.clear();
+  }
+
   private backupGateFor(toolName: string, args: any): any | null {
     const projectId = this.projectForCall(args);
     // Held calls are remembered by signature so a retry of a call that was
@@ -6007,6 +6020,7 @@ export class ToolHandlers {
         const created = matches.find((s: any) => s?.name === fields.name);
 
         this.snapshotCreatedForProject.add(data.projectId);
+        this.releaseBackupGateHolds(data.projectId);
 
         return withHints(
           {
@@ -6285,6 +6299,7 @@ export class ToolHandlers {
       // same session is still held once. Touches no API.
       case "decline": {
         this.backupDeclinedForProject.add(data.projectId);
+        this.releaseBackupGateHolds(data.projectId);
         return {
           operation: "decline",
           projectId: data.projectId,


### PR DESCRIPTION
## Summary

- Fixes a race in the `backup_not_offered` first-change hold: when an MCP client issued several mutating calls to the same project in one parallel batch (observed: three `update_tool` calls to project `6a884a69653367c48d249ac4`), only the first was held — the rest mutated the project before the backup offer was answered or declined.
- The gate's anti-deadlock release is now keyed on the call signature (tool name + args) instead of once-per-project, and the hold is marked synchronously before any async work — so all distinct concurrent mutations are held until `manage_snapshots create`/`decline` resolves, while a genuine retry of the same ignored call still proceeds (no deadlock).
- Adds tests simulating concurrent mutating calls for both the known-project and unknown-project gate paths.

## Changes

| File / Component            | Description                                                                                                                                                                                                        |
| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
| `src/tools/handlers.ts`     | `backupGateHeldForProject: Set<projectId>` → `backupGateHeldCallsForProject: Map<projectId, Set<signature>>`; global one-shot `backupGateTripped` boolean → per-signature set for calls whose project is unknown. |
| `src/__tests__/tools.test.ts` | Two new backup-gate tests: `Promise.all` of two distinct mutations to the same project must both return `backup_not_offered` with no API call (and proceed after decline); same for the unknown-project fallback. |

## Test plan

Automated:

- `npx tsc -p tsconfig.json --noEmit`
- `npm test` (588 passed, 3 skipped)

Manual:

- Existing anti-deadlock tests ("holds at most once, so a blind retry cannot deadlock", "holds each project only once") pass unchanged, confirming retry semantics are preserved.

## Breaking changes / migration

- None. Only behavioral change: a distinct concurrent/subsequent mutation issued while the offer is pending is now held too, instead of slipping through.

## Marketplace checklist

- [x] Versions left untouched — `package.json` and `plugin/.claude-plugin/plugin.json` are synced automatically by semantic-release on merge (`scripts/sync-plugin-version.mjs`); do not hand-edit either `version`
- [x] Tool count in `README.md` updated if the tool surface changed (unchanged)
- [x] `README.md` updated if user-facing behavior changed (no README-documented behavior changed)
- [x] Tool annotations/descriptions reviewed if tool behavior changed (gate error/hints unchanged)
- [x] `LICENSE` / marketplace metadata reviewed if submission requirements are affected (not affected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)