### PR TITLE
feat: enforce Cognigy Code Node best practices and standards at write…

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,12 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(npx eslint *)",
+      "Bash(npx tsc *)",
+      "Bash(./node_modules/.bin/eslint --version)",
+      "Bash(./node_modules/.bin/eslint src/tools/handlers.ts)",
+      "Bash(npm install *)",
+      "Bash(npm run *)"
+    ]
+  }
+}

--- a/plugin/skills/flow-nodes/SKILL.md
+++ b/plugin/skills/flow-nodes/SKILL.md
@@ -207,12 +207,55 @@ Run custom **TypeScript** (a single source string — not multiple files, not HT
 
 **Runtime objects available inside the code:**
 
-| Object    | What it is                                                             |
-| --------- | ---------------------------------------------------------------------- |
-| `input`   | The current input — read/write. `input.text`, `input.data`, etc.       |
-| `context` | Session-persistent store. Read/write values that survive across turns. |
-| `profile` | The contact profile.                                                   |
-| `actions` | Helper actions, e.g. `actions.output(text, data)`, `actions.log(...)`. |
+| Object    | What it is                                                                                   |
+| --------- | --------------------------------------------------------------------------------------------- |
+| `input`   | The current input — read/write. `input.text`, `input.flowName`, `input.sessionId`, etc.       |
+| `context` | Session-persistent store. Read via `context.x`; write and delete only through `api.*` below — never assign to it directly (`context.x = value` does not persist the way Cognigy expects). |
+| `profile` | The contact profile.                                                                           |
+| `api`     | The platform API. This is the **only** supported way to mutate context/input state, log, or control flow from a Code Node — see the allowlist and rules below. (`actions.*`, e.g. `actions.output()`/`actions.log()`, is a deprecated alias and must not be used in new or edited code.) |
+
+**Required shape — every Code Node must:**
+
+1. Wrap all logic in a single top-level `try { ... } catch (error) { ... }` block.
+2. Use the standardized catch block, setting `error`, `errorMessage`, `errorFlow`, `errorNode`, `errorTime`, `errorSessionId`, `errorUserId` and reporting it via `api.addToContext("codeNode", codeNode, "simple")`:
+
+   ```javascript
+   try {
+     // your script here
+   } catch (error) {
+     let codeNode = {
+       error: true,
+       errorMessage: `${error}`,
+       errorFlow: `${input.flowName}`,
+       errorNode: `NODE NAME`, // SET TO THE NAME OF THIS NODE
+       errorTime: input.currentTime.plain,
+       errorSessionId: input.sessionId,
+       errorUserId: input.userId,
+     };
+     api.addToContext("codeNode", codeNode, "simple");
+   }
+   ```
+
+3. Only call these `api.*` methods — anything else is rejected:
+
+   ```
+   api.addToContext()        api.getContext()          api.setContext()
+   api.deleteContext()       api.removeFromContext()    api.resetContext()
+   api.say() / api.output()  api.addToInput()           api.updateProfile()
+   api.setNextNode()         api.resetNextNodes()       api.stopExecution()
+   api.log()                 api.logDebugMessage()      api.logDebugError()
+   api.setAppState()         api.handover()             api.thinkV2()
+   api.base64Encode()        api.base64Decode()         api.completeGoal()
+   api.parseCognigyScript()  api.trackAnalyticsStep()
+   ```
+
+   `api.setState()`, `api.getState()`, and `api.resetState()` were **removed** in Cognigy.AI 2026.12.0 — use Intent Conditions instead.
+
+4. Never call `api.httpRequest()`, `fetch()`, `XMLHttpRequest`, `axios`, `node-fetch`, or `require()`/`import` of an unlisted module — there is no HTTP of any kind from a Code Node. Use a dedicated HTTP Request Node in the Flow instead.
+5. Avoid browser-only APIs (`toLocaleString()`, `toLocaleDateString()`, `toLocaleTimeString()`, `Intl.*`) — they aren't available in the Code Node's Node.js runtime. Use deterministic string/date handling instead.
+6. `api.deleteContext("key")` only deletes a **top-level** key — a dot-path argument (e.g. `api.deleteContext("temp.latencyStart")`) fails silently and leaves the key in place. For a nested key, use `delete context.temp.latencyStart;` or `api.removeFromContext("temp.latencyStart", null, "simple")` instead.
+
+`manage_flow_nodes` validates a Code Node's `code` against items 1–5 before writing it — a violation is rejected with the specific problem and, for the try/catch shape, the exact template to use. Items 6 (and a few other style checks: `var` usage, direct `context.x =` assignment, approaching the platform's line/API-call limits) come back as non-blocking warnings on the response instead of a rejection.
 
 **Config:**
 | Field | Type | Required | Description |
@@ -238,7 +281,7 @@ Then send the full new `code` string on `update` (config is merged; `code` is re
   "nodeType": "code",
   "label": "Format Response",
   "config": {
-    "code": "const items = context.cartItems || [];\ninput.cartSummary = items.map((i: { name: string; price: number }) => `${i.name}: $${i.price}`).join('\\n');"
+    "code": "try {\n  const items = context.cartItems || [];\n  const summary = items.map((i: { name: string; price: number }) => `${i.name}: $${i.price}`).join('\\n');\n  api.addToContext(\"cartSummary\", summary, \"simple\");\n} catch (error) {\n  let codeNode = {\n    error: true,\n    errorMessage: `${error}`,\n    errorFlow: `${input.flowName}`,\n    errorNode: `Format Response`,\n    errorTime: input.currentTime.plain,\n    errorSessionId: input.sessionId,\n    errorUserId: input.userId\n  };\n  api.addToContext(\"codeNode\", codeNode, \"simple\");\n}"
   }
 }
 ```

--- a/src/__tests__/httpTool.test.ts
+++ b/src/__tests__/httpTool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { CognigyApiClient } from "../api/client.js";
 import { ToolHandlers } from "../tools/handlers.js";
+import { STANDARD_CATCH_BLOCK } from "../tools/codeNodeValidation.js";
 
 // The backup gate holds the first change to an existing agent until the user
 // answers; suites that are not testing the gate answer it up front. The answer
@@ -21,6 +22,15 @@ const ID = {
   func: "60d5ec49f1a2c8b1a4e0f009",
   ext: "60d5ec49f1a2c8b1a4e0f00a",
 };
+
+/**
+ * Wraps a single line of Code Node logic in the standardized try/catch shape
+ * (see codeNodeValidation.ts) so fixtures satisfy the write-time enforcement
+ * this test file is not otherwise exercising.
+ */
+function wrapInStandardCatch(logic: string): string {
+  return STANDARD_CATCH_BLOCK.replace("// your script here", logic);
+}
 
 const MOCK_IDS = {
   toolNode: "aaaaaaaaaaaaaaaaaaaaa001",
@@ -163,7 +173,9 @@ describe("create_tool – HTTP tool path", () => {
     const result = await h.handleToolCall(
       "create_tool",
       baseArgs({
-        preProcessCode: "input.data = { transformed: true };",
+        preProcessCode: wrapInStandardCatch(
+          "input.data = { transformed: true };",
+        ),
       }),
     );
 
@@ -173,7 +185,9 @@ describe("create_tool – HTTP tool path", () => {
 
     const preCallBody = api.post.mock.calls[2][1];
     expect(preCallBody.type).toBe("code");
-    expect(preCallBody.config.code).toBe("input.data = { transformed: true };");
+    expect(preCallBody.config.code).toBe(
+      wrapInStandardCatch("input.data = { transformed: true };"),
+    );
     expect(preCallBody.label).toBe("My HTTP Tool - Pre-Process");
   });
 
@@ -189,7 +203,9 @@ describe("create_tool – HTTP tool path", () => {
     const result = await h.handleToolCall(
       "create_tool",
       baseArgs({
-        postProcessCode: "input.result = input.httprequest.data;",
+        postProcessCode: wrapInStandardCatch(
+          "input.result = input.httprequest.data;",
+        ),
       }),
     );
 
@@ -200,7 +216,7 @@ describe("create_tool – HTTP tool path", () => {
     const postCallBody = api.post.mock.calls[3][1];
     expect(postCallBody.type).toBe("code");
     expect(postCallBody.config.code).toBe(
-      "input.result = input.httprequest.data;",
+      wrapInStandardCatch("input.result = input.httprequest.data;"),
     );
     expect(postCallBody.label).toBe("My HTTP Tool - Post-Process");
   });
@@ -218,8 +234,8 @@ describe("create_tool – HTTP tool path", () => {
     const result = await h.handleToolCall(
       "create_tool",
       baseArgs({
-        preProcessCode: "input.pre = true;",
-        postProcessCode: "input.post = true;",
+        preProcessCode: wrapInStandardCatch("input.pre = true;"),
+        postProcessCode: wrapInStandardCatch("input.post = true;"),
       }),
     );
 
@@ -292,7 +308,7 @@ describe("create_tool – HTTP tool path", () => {
     await h.handleToolCall(
       "create_tool",
       baseArgs({
-        preProcessCode: "input.x = 1;",
+        preProcessCode: wrapInStandardCatch("input.x = 1;"),
       }),
     );
 
@@ -335,8 +351,8 @@ describe("create_tool – HTTP tool path", () => {
       config: {
         toolId: "fetch_user_posts",
         url: "https://api.example.com/posts",
-        preProcessCode: "input.x = 1;",
-        postProcessCode: "input.y = 2;",
+        preProcessCode: wrapInStandardCatch("input.x = 1;"),
+        postProcessCode: wrapInStandardCatch("input.y = 2;"),
       },
     });
 
@@ -436,13 +452,13 @@ describe("update_tool – HTTP child-node resolution", () => {
       aiAgentId: ID.agent,
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
-      config: { postProcessCode: "input.x = 1;" },
+      config: { postProcessCode: wrapInStandardCatch("input.x = 1;") },
     });
 
     expect(result.updatedFields).toContain("postProcessCode");
     expect(api.patch).toHaveBeenCalledWith(
       `/v2.0/flows/${ID.flow}/chart/nodes/${MOCK_IDS.postNode}`,
-      { config: { code: "input.x = 1;" } },
+      { config: { code: wrapInStandardCatch("input.x = 1;") } },
     );
   });
 
@@ -605,14 +621,14 @@ describe("update_tool – HTTP child-node resolution", () => {
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
       config: {
-        postProcessCode: "input.y = 2;",
+        postProcessCode: wrapInStandardCatch("input.y = 2;"),
         postProcessNodeId: MOCK_IDS.postNode,
       },
     });
 
     expect(api.patch).toHaveBeenCalledWith(
       `/v2.0/flows/${ID.flow}/chart/nodes/${MOCK_IDS.postNode}`,
-      { config: { code: "input.y = 2;" } },
+      { config: { code: wrapInStandardCatch("input.y = 2;") } },
     );
   });
 
@@ -645,7 +661,9 @@ describe("update_tool – HTTP child-node resolution", () => {
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
       config: {
-        postProcessCode: "input.recipes = input.httprequest.body.meals;",
+        postProcessCode: wrapInStandardCatch(
+          "input.recipes = input.httprequest.body.meals;",
+        ),
       },
     });
 
@@ -658,7 +676,11 @@ describe("update_tool – HTTP child-node resolution", () => {
         mode: "append",
         target: MOCK_IDS.httpNode,
         label: "search_recipes - Post-Process",
-        config: { code: "input.recipes = input.httprequest.body.meals;" },
+        config: {
+          code: wrapInStandardCatch(
+            "input.recipes = input.httprequest.body.meals;",
+          ),
+        },
       }),
     );
   });
@@ -690,8 +712,9 @@ describe("update_tool – HTTP child-node resolution", () => {
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
       config: {
-        preProcessCode:
+        preProcessCode: wrapInStandardCatch(
           'input.normalized = String(input.aiAgent.toolArgs.q || "").trim();',
+        ),
       },
     });
 
@@ -726,7 +749,7 @@ describe("update_tool – HTTP child-node resolution", () => {
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
       config: {
-        preProcessCode: "input.x = 1;",
+        preProcessCode: wrapInStandardCatch("input.x = 1;"),
         preProcessNodeId: "aaaaaaaaaaaaaaaaaaaaadea",
       },
     });
@@ -753,7 +776,7 @@ describe("update_tool – HTTP child-node resolution", () => {
       aiAgentId: ID.agent,
       toolNodeId: MOCK_IDS.toolNode,
       toolType: "http",
-      config: { postProcessCode: "input.x = 1;" },
+      config: { postProcessCode: wrapInStandardCatch("input.x = 1;") },
     });
 
     expect(result.updatedFields).not.toContain("postProcessCode");

--- a/src/__tests__/tools.test.ts
+++ b/src/__tests__/tools.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import { Readable } from "stream";
 import { CognigyApiClient } from "../api/client.js";
 import { ToolHandlers } from "../tools/handlers.js";
+import { STANDARD_CATCH_BLOCK } from "../tools/codeNodeValidation.js";
 
 // Valid 24-char hex IDs for tests
 const ID = {
@@ -23,6 +24,15 @@ const ID = {
   task: "60d5ec49f1a2c8b1a4e0f00c",
   task2: "60d5ec49f1a2c8b1a4e0f00d",
 };
+
+/**
+ * Wraps a single line of Code Node logic in the standardized try/catch shape
+ * (see codeNodeValidation.ts) so fixtures satisfy the write-time enforcement
+ * this test file is not otherwise exercising.
+ */
+function wrapInStandardCatch(logic: string): string {
+  return STANDARD_CATCH_BLOCK.replace("// your script here", logic);
+}
 
 /**
  * The server holds the first change to an existing agent in a session until a
@@ -2212,7 +2222,7 @@ describe("ToolHandlers v2", () => {
         operation: "update",
         flowId: ID.flow,
         nodeId: codeNodeId,
-        config: { code: "const x: =" },
+        config: { code: wrapInStandardCatch("const x: =") },
       });
 
       expect(result.updated).toBe(true);
@@ -2237,7 +2247,7 @@ describe("ToolHandlers v2", () => {
         operation: "update",
         flowId: ID.flow,
         nodeId: codeNodeId,
-        config: { code: "input.ok = 1;" },
+        config: { code: wrapInStandardCatch("input.ok = 1;") },
       });
 
       expect(result.updated).toBe(true);
@@ -2279,13 +2289,13 @@ describe("ToolHandlers v2", () => {
         operation: "update",
         flowId: ID.flow,
         nodeId: codeNodeId,
-        config: { code: "input.ok = 1;" },
+        config: { code: wrapInStandardCatch("input.ok = 1;") },
       });
 
       const patchBody = api.patch.mock.calls[0][1];
       expect(patchBody.config).not.toHaveProperty("transpiled");
       expect(patchBody.config).not.toHaveProperty("hasError");
-      expect(patchBody.config.code).toBe("input.ok = 1;");
+      expect(patchBody.config.code).toBe(wrapInStandardCatch("input.ok = 1;"));
     });
   });
 
@@ -2335,7 +2345,7 @@ describe("ToolHandlers v2", () => {
         mode: "appendChild",
         nodeType: "code",
         label: "Process",
-        config: { code: 'input.result = "done";' },
+        config: { code: wrapInStandardCatch('input.result = "done";') },
       });
 
       expect(result.mode).toBe("append");

--- a/src/__tests__/updateTool.test.ts
+++ b/src/__tests__/updateTool.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, jest } from "@jest/globals";
 import { CognigyApiClient } from "../api/client.js";
 import { ToolHandlers } from "../tools/handlers.js";
+import { STANDARD_CATCH_BLOCK } from "../tools/codeNodeValidation.js";
 
 // The backup gate holds the first change to an existing agent until the user
 // answers; suites that are not testing the gate answer it up front. The answer
@@ -21,6 +22,15 @@ const ID = {
   func: "60d5ec49f1a2c8b1a4e0f009",
   ext: "60d5ec49f1a2c8b1a4e0f00a",
 };
+
+/**
+ * Wraps a single line of Code Node logic in the standardized try/catch shape
+ * (see codeNodeValidation.ts) so fixtures satisfy the write-time enforcement
+ * this test file is not otherwise exercising.
+ */
+function wrapInStandardCatch(logic: string): string {
+  return STANDARD_CATCH_BLOCK.replace("// your script here", logic);
+}
 
 describe("update_tool", () => {
   let api: jest.Mocked<CognigyApiClient>;
@@ -250,14 +260,14 @@ describe("update_tool", () => {
     const result = await h.handleToolCall("update_tool", {
       aiAgentId: ID.agent,
       toolNodeId: ID.tool,
-      config: { preProcessCode: "input.newField = true;" },
+      config: { preProcessCode: wrapInStandardCatch("input.newField = true;") },
     });
 
     expect(result.updated).toBe(true);
     expect(result.updatedFields).toContain("preProcessCode");
     expect(api.patch).toHaveBeenCalledWith(
       `/v2.0/flows/${ID.flow}/chart/nodes/code-pre-001`,
-      { config: { code: "input.newField = true;" } },
+      { config: { code: wrapInStandardCatch("input.newField = true;") } },
     );
   });
 
@@ -283,14 +293,16 @@ describe("update_tool", () => {
     const result = await h.handleToolCall("update_tool", {
       aiAgentId: ID.agent,
       toolNodeId: ID.tool,
-      config: { postProcessCode: 'output.result = "done";' },
+      config: {
+        postProcessCode: wrapInStandardCatch('output.result = "done";'),
+      },
     });
 
     expect(result.updated).toBe(true);
     expect(result.updatedFields).toContain("postProcessCode");
     expect(api.patch).toHaveBeenCalledWith(
       `/v2.0/flows/${ID.flow}/chart/nodes/code-post-001`,
-      { config: { code: 'output.result = "done";' } },
+      { config: { code: wrapInStandardCatch('output.result = "done";') } },
     );
   });
 
@@ -302,7 +314,10 @@ describe("update_tool", () => {
     const result = await h.handleToolCall("update_tool", {
       aiAgentId: ID.agent,
       toolNodeId: ID.tool,
-      config: { preProcessCode: "x = 1;", postProcessCode: "y = 2;" },
+      config: {
+        preProcessCode: wrapInStandardCatch("x = 1;"),
+        postProcessCode: wrapInStandardCatch("y = 2;"),
+      },
     });
 
     expect(result._hints).toBeDefined();

--- a/src/schemas/tools.ts
+++ b/src/schemas/tools.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import { validateCodeNode } from "../tools/codeNodeValidation.js";
 
 const idSchema = z.string().regex(/^[a-f0-9]{24}$/, "Must be a 24-char hex ID");
 
@@ -6,6 +7,29 @@ const paginationSchema = {
   limit: z.number().int().min(1).max(100).optional(),
   skip: z.number().int().min(0).optional(),
 };
+
+/**
+ * Runs the shared Code Node validator against a config field and, if it
+ * reports blocking errors, raises a Zod issue at that field's path. Warnings
+ * are not raised here — they don't block the write; they're surfaced by the
+ * handler after a successful create/update instead. No-ops when the field is
+ * undefined (the caller isn't setting/changing this code).
+ */
+function refineCodeField(
+  ctx: z.RefinementCtx,
+  code: string | undefined,
+  path: (string | number)[],
+) {
+  if (code === undefined) return;
+  const result = validateCodeNode(code);
+  if (result.errors.length > 0) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      path,
+      message: result.errors.join(" "),
+    });
+  }
+}
 
 // Tool 1: create_ai_agent
 export const createAiAgentSchema = z.object({
@@ -260,40 +284,12 @@ export const manageKnowledgeSchema = z.object({
 });
 
 // Tool 9: create_tool (includes http tool type, formerly create_custom_http_tool)
-export const createToolSchema = z.object({
-  aiAgentId: idSchema,
-  toolType: z.enum(["tool", "knowledge", "send_email", "mcp", "http"]),
-  name: z.string().min(1).max(200),
-  config: z.object({
-    toolId: z.string().optional(),
-    description: z.string().optional(),
-    parameters: z.string().optional(),
-    knowledgeStoreId: z.string().optional(),
-    topK: z.number().int().min(1).max(50).optional(),
-    recipient: z.string().optional(),
-    mcpServerUrl: z.string().optional(),
-    mcpName: z.string().optional(),
-    timeout: z.number().optional(),
-    url: z.string().optional(),
-    method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
-    headers: z.record(z.string()).optional(),
-    body: z.string().optional(),
-    preProcessCode: z.string().optional(),
-    postProcessCode: z.string().optional(),
-    toolResponseValue: z.string().optional(),
-  }),
-});
-
-// Tool 10: update_tool
-export const updateToolSchema = z.object({
-  aiAgentId: idSchema,
-  toolNodeId: idSchema,
-  name: z.string().min(1).max(200).optional(),
-  toolType: z
-    .enum(["tool", "knowledge", "send_email", "mcp", "http"])
-    .optional(),
-  config: z
-    .object({
+export const createToolSchema = z
+  .object({
+    aiAgentId: idSchema,
+    toolType: z.enum(["tool", "knowledge", "send_email", "mcp", "http"]),
+    name: z.string().min(1).max(200),
+    config: z.object({
       toolId: z.string().optional(),
       description: z.string().optional(),
       parameters: z.string().optional(),
@@ -310,31 +306,93 @@ export const updateToolSchema = z.object({
       preProcessCode: z.string().optional(),
       postProcessCode: z.string().optional(),
       toolResponseValue: z.string().optional(),
-      httpNodeId: idSchema.optional(),
-      preProcessNodeId: idSchema.optional(),
-      postProcessNodeId: idSchema.optional(),
-      resolveNodeId: idSchema.optional(),
-    })
-    .optional(),
-});
+    }),
+  })
+  .superRefine((data, ctx) => {
+    refineCodeField(ctx, data.config.preProcessCode, [
+      "config",
+      "preProcessCode",
+    ]);
+    refineCodeField(ctx, data.config.postProcessCode, [
+      "config",
+      "postProcessCode",
+    ]);
+  });
+
+// Tool 10: update_tool
+export const updateToolSchema = z
+  .object({
+    aiAgentId: idSchema,
+    toolNodeId: idSchema,
+    name: z.string().min(1).max(200).optional(),
+    toolType: z
+      .enum(["tool", "knowledge", "send_email", "mcp", "http"])
+      .optional(),
+    config: z
+      .object({
+        toolId: z.string().optional(),
+        description: z.string().optional(),
+        parameters: z.string().optional(),
+        knowledgeStoreId: z.string().optional(),
+        topK: z.number().int().min(1).max(50).optional(),
+        recipient: z.string().optional(),
+        mcpServerUrl: z.string().optional(),
+        mcpName: z.string().optional(),
+        timeout: z.number().optional(),
+        url: z.string().optional(),
+        method: z.enum(["GET", "POST", "PUT", "PATCH", "DELETE"]).optional(),
+        headers: z.record(z.string()).optional(),
+        body: z.string().optional(),
+        preProcessCode: z.string().optional(),
+        postProcessCode: z.string().optional(),
+        toolResponseValue: z.string().optional(),
+        httpNodeId: idSchema.optional(),
+        preProcessNodeId: idSchema.optional(),
+        postProcessNodeId: idSchema.optional(),
+        resolveNodeId: idSchema.optional(),
+      })
+      .optional(),
+  })
+  .superRefine((data, ctx) => {
+    refineCodeField(ctx, data.config?.preProcessCode, [
+      "config",
+      "preProcessCode",
+    ]);
+    refineCodeField(ctx, data.config?.postProcessCode, [
+      "config",
+      "postProcessCode",
+    ]);
+  });
 
 // Tool 12: manage_flow_nodes
-export const manageFlowNodesSchema = z.object({
-  operation: z.enum(["list", "get", "create", "update", "delete", "render"]),
-  flowId: idSchema,
-  nodeId: idSchema.optional(),
-  nodeType: z.string().optional(),
-  label: z.string().min(1).max(200).optional(),
-  parentNodeId: idSchema.optional(),
-  mode: z.enum(["append", "appendChild"]).optional(),
-  config: z.record(z.any()).optional(),
-  // render operation
-  focus: z.union([idSchema, z.array(idSchema)]).optional(),
-  format: z.enum(["ascii", "mermaid", "both"]).optional(),
-  legend: z.boolean().optional(),
-  writeHtml: z.boolean().optional(),
-  openInBrowser: z.boolean().optional(),
-});
+export const manageFlowNodesSchema = z
+  .object({
+    operation: z.enum(["list", "get", "create", "update", "delete", "render"]),
+    flowId: idSchema,
+    nodeId: idSchema.optional(),
+    nodeType: z.string().optional(),
+    label: z.string().min(1).max(200).optional(),
+    parentNodeId: idSchema.optional(),
+    mode: z.enum(["append", "appendChild"]).optional(),
+    config: z.record(z.any()).optional(),
+    // render operation
+    focus: z.union([idSchema, z.array(idSchema)]).optional(),
+    format: z.enum(["ascii", "mermaid", "both"]).optional(),
+    legend: z.boolean().optional(),
+    writeHtml: z.boolean().optional(),
+    openInBrowser: z.boolean().optional(),
+  })
+  .superRefine((data, ctx) => {
+    // Standalone Code nodes created directly via manage_flow_nodes. The
+    // update path can't be checked here — the existing node's type isn't
+    // known until handlers.ts fetches it — so that half lives in handlers.ts.
+    if (data.operation === "create" && data.nodeType === "code") {
+      refineCodeField(ctx, data.config?.code as string | undefined, [
+        "config",
+        "code",
+      ]);
+    }
+  });
 
 // Tool 13: manage_packages
 const packageResourceSelectionSchema = z.object({

--- a/src/tools/codeNodeValidation.ts
+++ b/src/tools/codeNodeValidation.ts
@@ -1,0 +1,268 @@
+/**
+ * Validation for Cognigy Code Node content against NA Professional Services
+ * standards (see the `na-professionalservices` skill, `cognigyCodeDev.md`,
+ * sections: "Code Node Rules", "Standardized Catch Block", "Allowed API
+ * Functions", "api.setState() ... Removed", "api.deleteContext() ...",
+ * "Writing to Context", "No HTTP in Code Nodes", "Environment Constraints",
+ * "Coding Standards").
+ *
+ * Current scope, per team decisions:
+ *   - Comment-header enforcement is out of scope (tracked separately).
+ *   - The "no function declarations inside a Code Node" rule is out of
+ *     scope for now (tracked separately).
+ *   - `errorEnv` is intentionally NOT part of the required catch fields —
+ *     the team standard was trimmed to only fields sourced from the error
+ *     itself or from `input`, since an environment lookup can't be assumed
+ *     to exist on every agent.
+ *
+ * This is a structural/text check, not a full JS/TS parse — Code Nodes are
+ * TypeScript, transpiled server-side, and we don't have that transpiler
+ * available locally. Checks are intentionally pattern-based rather than a
+ * strict AST match, so minor formatting differences (spacing, variable name
+ * for the caught error) don't produce false failures.
+ */
+
+export interface CodeNodeValidationResult {
+  /** Blocking problems — code with any of these should not be written. */
+  errors: string[];
+  /** Non-blocking problems — code proceeds, but the caller should be told. */
+  warnings: string[];
+}
+
+/** Fields the standardized catch block must set on the `codeNode` error object. */
+const REQUIRED_CATCH_FIELDS = [
+  "error",
+  "errorMessage",
+  "errorFlow",
+  "errorNode",
+  "errorTime",
+  "errorSessionId",
+  "errorUserId",
+] as const;
+
+/**
+ * The standardized catch block template, current team version (errorEnv
+ * removed — see the module doc comment above for why). Surfaced in
+ * validation error messages so callers can copy it directly instead of
+ * reconstructing it from the rule description.
+ */
+export const STANDARD_CATCH_BLOCK = `try {
+  // your script here
+} catch (error) {
+  let codeNode = {
+    error: true,
+    errorMessage: \`\${error}\`,
+    errorFlow: \`\${input.flowName}\`,
+    errorNode: \`NODE NAME\`, // SET TO THE NAME OF THE FLOW THIS IS FOR
+    errorTime: input.currentTime.plain,
+    errorSessionId: input.sessionId,
+    errorUserId: input.userId
+  };
+  api.addToContext("codeNode", codeNode, "simple");
+}`;
+
+/** The only api.* methods the platform actually supports (cognigyCodeDev "Allowed API Functions"). */
+const ALLOWED_API_METHODS = new Set([
+  "addToContext",
+  "getContext",
+  "setContext",
+  "deleteContext",
+  "removeFromContext",
+  "resetContext",
+  "say",
+  "output",
+  "addToInput",
+  "updateProfile",
+  "setNextNode",
+  "resetNextNodes",
+  "stopExecution",
+  "log",
+  "logDebugMessage",
+  "logDebugError",
+  "setAppState",
+  "handover",
+  "thinkV2",
+  "base64Encode",
+  "base64Decode",
+  "completeGoal",
+  "parseCognigyScript",
+  "trackAnalyticsStep",
+]);
+
+/** Methods removed in Cognigy.AI 2026.12.0 — called out with a specific message. */
+const REMOVED_STATE_METHODS = new Set(["setState", "getState", "resetState"]);
+
+/** Browser-only APIs that don't exist in the Code Node's Node.js runtime. */
+const BANNED_BROWSER_APIS = [
+  /\.toLocaleString\s*\(/,
+  /\.toLocaleDateString\s*\(/,
+  /\.toLocaleTimeString\s*\(/,
+  /\bIntl\./,
+];
+
+/** Approximate soft ceiling used only to warn on unusually large Code Nodes. */
+const LINE_COUNT_LIMIT = 200_000;
+/** Approximate soft ceiling on api.* calls per Code Node (platform limit is 100). */
+const API_CALL_WARNING_THRESHOLD = 100;
+
+function checkTryCatch(code: string, errors: string[]): void {
+  const hasTry = /\btry\s*{/.test(code);
+  const hasCatch = /}\s*catch\s*\(\s*\w+\s*\)\s*{/.test(code);
+
+  if (!hasTry || !hasCatch) {
+    errors.push(
+      "Code must wrap all logic in a try/catch block — every Code Node body needs a top-level try { ... } catch (error) { ... }.",
+    );
+    return;
+  }
+
+  // Isolate the catch block body so the field checks below don't false-positive
+  // on unrelated code elsewhere in the node that happens to mention these words.
+  const catchBodyMatch = code.match(/catch\s*\(\s*\w+\s*\)\s*{([\s\S]*)}\s*$/);
+  const catchBody = catchBodyMatch ? catchBodyMatch[1] : code;
+
+  const missingFields = REQUIRED_CATCH_FIELDS.filter(
+    (field) => !new RegExp(`\\b${field}\\b`).test(catchBody),
+  );
+  if (missingFields.length > 0) {
+    errors.push(
+      `catch block is missing required field(s): ${missingFields.join(", ")}. Use the standardized catch block from the cognigyCodeDev skill.`,
+    );
+  }
+
+  if (!/api\.addToContext\(\s*["']codeNode["']/.test(catchBody)) {
+    errors.push(
+      'catch block must report the error via api.addToContext("codeNode", ..., "simple") — the standardized catch block is missing or was not detected.',
+    );
+  }
+}
+
+function checkApiAllowlist(code: string, errors: string[]): void {
+  const calls = code.matchAll(/\bapi\.(\w+)\s*\(/g);
+  const seen = new Set<string>();
+  for (const match of calls) {
+    const method = match[1];
+    if (seen.has(method)) continue;
+    seen.add(method);
+
+    if (REMOVED_STATE_METHODS.has(method)) {
+      errors.push(
+        `api.${method}() was removed in Cognigy.AI 2026.12.0 and cannot be used. Use Intent Conditions to control intent recognition instead.`,
+      );
+      continue;
+    }
+
+    if (!ALLOWED_API_METHODS.has(method)) {
+      errors.push(
+        `api.${method}() is not a supported Cognigy Code Node API method. Allowed methods: ${Array.from(ALLOWED_API_METHODS).join(", ")}.`,
+      );
+    }
+  }
+}
+
+function checkNoHttpOrModules(code: string, errors: string[]): void {
+  if (/\bapi\.httpRequest\s*\(/.test(code)) {
+    errors.push(
+      "api.httpRequest() does not exist. HTTP calls must use a dedicated HTTP Request Node in the Flow, not a Code Node.",
+    );
+  }
+  if (/\bfetch\s*\(/.test(code) || /\bXMLHttpRequest\b/.test(code)) {
+    errors.push(
+      "fetch()/XMLHttpRequest are not available in the Code Node runtime. Use a dedicated HTTP Request Node in the Flow instead.",
+    );
+  }
+  if (/\baxios\b/.test(code)) {
+    errors.push(
+      "axios is not available in the Code Node runtime. Use a dedicated HTTP Request Node in the Flow instead.",
+    );
+  }
+  if (/require\s*\(\s*["']node-fetch["']\s*\)/.test(code)) {
+    errors.push(
+      "node-fetch is not available in the Code Node runtime. Use a dedicated HTTP Request Node in the Flow instead.",
+    );
+  }
+  if (/\brequire\s*\(/.test(code) || /^\s*import\s+.+\bfrom\b/m.test(code)) {
+    errors.push(
+      "require()/import of a module was detected. Only modules explicitly documented as available in Cognigy's Code Node environment may be used — check the Available Modules reference before including this.",
+    );
+  }
+}
+
+function checkBannedBrowserApis(code: string, errors: string[]): void {
+  if (BANNED_BROWSER_APIS.some((pattern) => pattern.test(code))) {
+    errors.push(
+      "Code uses a browser-only API (toLocaleString/toLocaleDateString/toLocaleTimeString/Intl.*) that isn't available in the Code Node's Node.js runtime. Use deterministic string/date handling instead (e.g. substring, regex, plain arithmetic).",
+    );
+  }
+}
+
+function checkDeleteContextNestedPath(code: string, warnings: string[]): void {
+  const nestedDeleteCalls = code.match(
+    /api\.deleteContext\(\s*["'][^"']*\.[^"']*["']/g,
+  );
+  if (nestedDeleteCalls) {
+    warnings.push(
+      'api.deleteContext() only deletes top-level keys — a dot-path argument (e.g. "temp.latencyStart") fails silently and leaves the key in place. For a nested key, use `delete context.temp.latencyStart;` or api.removeFromContext("temp.latencyStart", null, "simple") instead.',
+    );
+  }
+}
+
+function checkDirectContextAssignment(code: string, warnings: string[]): void {
+  // `delete context.x;` is the documented, correct way to remove a nested key
+  // (see checkDeleteContextNestedPath above) — strip those statements first so
+  // they aren't mistaken for a direct assignment.
+  const withoutDeletes = code.replace(/delete\s+context\.[\w$.]+\s*;?/g, "");
+  if (/\bcontext\.[\w$.]+\s*=(?!=)/.test(withoutDeletes)) {
+    warnings.push(
+      'Code appears to assign directly to context (e.g. "context.x = value") instead of using api.addToContext("path.to.key", value, "simple"). Direct assignment does not persist the way Cognigy expects — use api.addToContext() to write to context.',
+    );
+  }
+}
+
+function checkVarUsage(code: string, warnings: string[]): void {
+  if (/\bvar\s+\w+/.test(code)) {
+    warnings.push(
+      "Code uses `var`, which is function-scoped and hoisted and can cause unexpected bugs. Use `const` for values that aren't reassigned and `let`, scoped as tightly as possible, for values that are.",
+    );
+  }
+}
+
+function checkSizeAndCallLimits(code: string, warnings: string[]): void {
+  const lineCount = code.split("\n").length;
+  if (lineCount > LINE_COUNT_LIMIT) {
+    warnings.push(
+      `Code is ${lineCount} lines, at or beyond the platform's 200,000-line Code Node limit.`,
+    );
+  }
+
+  const apiCallCount = (code.match(/\bapi\.\w+\s*\(/g) ?? []).length;
+  if (apiCallCount > API_CALL_WARNING_THRESHOLD) {
+    warnings.push(
+      `Code makes approximately ${apiCallCount} api.* calls, above the platform's 100-API-call-per-node limit (this count is a textual approximation, not an exact runtime count).`,
+    );
+  }
+}
+
+/**
+ * Validates a Code Node's `code` string against the team's Cognigy Code Node
+ * standards. Returns blocking `errors` (code that is guaranteed-broken or
+ * guaranteed-nonfunctional on the platform) separately from non-blocking
+ * `warnings` (code that may work but is risky, silently wrong, or against
+ * style guidance).
+ */
+export function validateCodeNode(code: string): CodeNodeValidationResult {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+
+  checkTryCatch(code, errors);
+  checkApiAllowlist(code, errors);
+  checkNoHttpOrModules(code, errors);
+  checkBannedBrowserApis(code, errors);
+
+  checkDeleteContextNestedPath(code, warnings);
+  checkDirectContextAssignment(code, warnings);
+  checkVarUsage(code, warnings);
+  checkSizeAndCallLimits(code, warnings);
+
+  return { errors, warnings };
+}

--- a/src/tools/definitions.ts
+++ b/src/tools/definitions.ts
@@ -567,7 +567,7 @@ export const tools: ToolDefinition[] = [
     name: "create_tool",
     description: `Create a tool as a child of an AI Agent's Job node. Tools extend what the agent can do.
 
-IMPORTANT — environment-specific conventions that are NOT obvious from this schema and that silently produce broken tools when missed: the wrapped HTTP response shape (input.httprequest is an object containing { result, statusCode, length }, NOT the raw response body), where LLM tool-call arguments live (input.aiAgent.toolArgs.<param>, NOT input.data), and Code-node rules (top-level return is forbidden — mutate input directly). Assuming "REST is obvious" or "Code nodes are just JS" is the most common cause of HTTP tools that fire successfully but return empty results to the LLM.
+IMPORTANT — environment-specific conventions that are NOT obvious from this schema and that silently produce broken tools when missed: the wrapped HTTP response shape (input.httprequest is an object containing { result, statusCode, length }, NOT the raw response body), where LLM tool-call arguments live (input.aiAgent.toolArgs.<param>, NOT input.data), and Code-node rules (top-level return is forbidden — mutate input directly; all logic must be wrapped in a single top-level try/catch, or the node is rejected — see preProcessCode/postProcessCode below for the required catch shape). Assuming "REST is obvious" or "Code nodes are just JS" is the most common cause of HTTP tools that fire successfully but return empty results to the LLM.
 
 Tool types:
 - tool: General-purpose tool with custom logic branch. Use this for most requests (e.g., "unlock account", "check status", "validate input"). Provide toolId, description, and optional parameters (JSON Schema). After creation, use manage_flow_nodes with parentNodeId = returned toolNodeId and mode = "appendChild" to add logic nodes (say, code, ifThenElse, httpRequest, etc.) inside the tool branch.
@@ -678,12 +678,12 @@ After creating, use talk_to_agent to test.`,
             preProcessCode: {
               type: "string",
               description:
-                "JavaScript code to run BEFORE the HTTP request. Runs in Cognigy's Code Node environment with access to input, context, actions (http only).",
+                'JavaScript code to run BEFORE the HTTP request. Runs in Cognigy\'s Code Node environment with access to input, context, actions (http only). Required shape: wrap all logic in a top-level try/catch. On catch, set { error: true, errorMessage, errorFlow, errorNode, errorTime, errorSessionId, errorUserId } and write it with api.addToContext("codeNode", ..., "simple"). Only documented api.* methods are allowed (no api.setState/getState/resetState — removed; use Intent Conditions). No HTTP calls, fetch/axios/require/import, or browser-only date APIs (toLocaleString, etc.) — code violating these is rejected before the tool is created. See the cognigyCodeDev skill for the exact template.',
             },
             postProcessCode: {
               type: "string",
               description:
-                "JavaScript code to run AFTER the HTTP response. Runs in Cognigy's Code Node environment with access to input, context, actions (http only).",
+                "JavaScript code to run AFTER the HTTP response. Runs in Cognigy's Code Node environment with access to input, context, actions (http only). Same requirements as preProcessCode — see that field's description for the required try/catch shape and disallowed patterns.",
             },
             toolResponseValue: {
               type: "string",
@@ -796,12 +796,12 @@ After creating, use talk_to_agent to test.`,
             preProcessCode: {
               type: "string",
               description:
-                "JavaScript code for the pre-process Code node (http only)",
+                "JavaScript code for the pre-process Code node (http only). Must wrap all logic in a top-level try/catch with the standard catch shape, use only documented api.* methods, and avoid HTTP/require/import and browser-only date APIs — see create_tool's preProcessCode description for the full list. Rejected before the update is applied if violated.",
             },
             postProcessCode: {
               type: "string",
               description:
-                "JavaScript code for the post-process Code node (http only)",
+                "JavaScript code for the post-process Code node (http only). Same requirements as preProcessCode.",
             },
             toolResponseValue: {
               type: "string",
@@ -839,7 +839,7 @@ After creating, use talk_to_agent to test.`,
   {
     name: "manage_flow_nodes",
     description:
-      'Manage the logic nodes inside a flow (list/get/create/update/delete) and render the flow as a diagram. Nodes are helpers that live INSIDE AI Agent tool branches: create a tool first (create_tool { toolType: "tool" }), then add nodes with parentNodeId = toolNodeId, mode = "appendChild". NEVER add standalone nodes before the AI Agent Job node. The flow-nodes skill owns the full workflow — placement, branching (ifThenElse/lookup), node config, and case values.\n\nOPERATIONS:\n- list: all nodes in a flow (id, type, label, parentId, isEntryPoint only — NO config).\n- get: one node in full incl. config (requires nodeId). Read before editing. For code nodes the config reports `hasError`; the large server-computed `transpiled` output is omitted.\n- create: add a node (requires nodeType + config). parentNodeId + mode place it — see the flow-nodes skill.\n- update: change a node\'s config or label (only provided fields change). For switch/lookup nodes, pass a `cases` array to set case values.\n- delete: remove a node.\n- render (read-only): visualize the flow. Returns an `ascii` tree (display inline in any client incl. terminal) and a `mermaid` string. Deliver the mermaid ONLY as a native Mermaid/diagram artifact — do NOT wrap it in HTML or paste it as an inline ```mermaid fence (both break the zoomable, mobile-friendly viewer). Options: focus=<nodeId|nodeId[]> highlights nodes; writeHtml writes a self-contained rich HTML graph to a local tmp file and opens it in the browser (returns htmlUrl/htmlPath — the file is already on the user\'s machine, just hand them the link). See the flow-nodes skill for details.\n\nSupported node types come from the server node registry; an unsupported nodeType returns the current list. For AI Agent tool nodes (knowledge, send_email, mcp, http) use create_tool / update_tool instead.',
+      'Manage the logic nodes inside a flow (list/get/create/update/delete) and render the flow as a diagram. Nodes are helpers that live INSIDE AI Agent tool branches: create a tool first (create_tool { toolType: "tool" }), then add nodes with parentNodeId = toolNodeId, mode = "appendChild". NEVER add standalone nodes before the AI Agent Job node. The flow-nodes skill owns the full workflow — placement, branching (ifThenElse/lookup), node config, and case values.\n\nOPERATIONS:\n- list: all nodes in a flow (id, type, label, parentId, isEntryPoint only — NO config).\n- get: one node in full incl. config (requires nodeId). Read before editing. For code nodes the config reports `hasError`; the large server-computed `transpiled` output is omitted.\n- create: add a node (requires nodeType + config). parentNodeId + mode place it — see the flow-nodes skill. For nodeType "code", config.code must wrap all logic in a top-level try/catch with the standard catch shape (error, errorMessage, errorFlow, errorNode, errorTime, errorSessionId, errorUserId, reported via api.addToContext("codeNode", ..., "simple")), use only documented api.* methods (no api.setState/getState/resetState — removed; use Intent Conditions), and avoid HTTP calls/fetch/axios/require/import and browser-only date APIs — code violating these is rejected before the node is created. Non-blocking style warnings (nested-path api.deleteContext(), direct context.x assignment, var usage, approaching line/api-call limits) are returned but do not block the write.\n- update: change a node\'s config or label (only provided fields change). For switch/lookup nodes, pass a `cases` array to set case values. For an existing "code" node, the same try/catch/allowlist/HTTP requirements as create apply to config.code and are rejected before the update is applied; the same non-blocking warnings apply.\n- delete: remove a node.\n- render (read-only): visualize the flow. Returns an `ascii` tree (display inline in any client incl. terminal) and a `mermaid` string. Deliver the mermaid ONLY as a native Mermaid/diagram artifact — do NOT wrap it in HTML or paste it as an inline ```mermaid fence (both break the zoomable, mobile-friendly viewer). Options: focus=<nodeId|nodeId[]> highlights nodes; writeHtml writes a self-contained rich HTML graph to a local tmp file and opens it in the browser (returns htmlUrl/htmlPath — the file is already on the user\'s machine, just hand them the link). See the flow-nodes skill for details.\n\nSupported node types come from the server node registry; an unsupported nodeType returns the current list. For AI Agent tool nodes (knowledge, send_email, mcp, http) use create_tool / update_tool instead.',
     annotations: {
       title: "Manage Flow Nodes",
       readOnlyHint: false,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -26,6 +26,10 @@ import { buildWebchatSettings, deepMerge } from "./webchatSettings.js";
 import { normalizeToolParameters } from "./toolParameters.js";
 import { getNodeEntry, supportedNodeTypes } from "./nodeRegistry.js";
 import {
+  validateCodeNode,
+  STANDARD_CATCH_BLOCK,
+} from "./codeNodeValidation.js";
+import {
   evaluateChecks,
   summarize,
   nodeId as voiceNodeId,
@@ -4199,6 +4203,16 @@ export class ToolHandlers {
           configApplied: data.config ? Object.keys(data.config) : [],
         };
 
+        // Code Node content warnings (non-blocking) — the hard try/catch/
+        // allowlist/HTTP checks already ran in manageFlowNodesSchema's
+        // superRefine and would have thrown before this point. These are
+        // the softer, non-blocking signals (schema-level refinements can
+        // only reject, not warn, so this runs post-write).
+        const codeWarnings: string[] =
+          entry.type === "code" && typeof data.config?.code === "string"
+            ? validateCodeNode(data.config.code).warnings
+            : [];
+
         if (missingInitAppSession) {
           return withRenderSuggestion(
             withHints(result, {
@@ -4206,6 +4220,18 @@ export class ToolHandlers {
                 "No xApp: Init Session (initAppSession) node exists in this flow. Every xApp node needs one, and it must run before this node — it creates the session and populates input.apps.url. (This check only verifies presence, not execution order.)",
               action:
                 "Add an initAppSession node and ensure it runs before this xApp node (earlier in the same tool branch).",
+            }),
+            flowId,
+            nodeId,
+          );
+        }
+
+        if (codeWarnings.length > 0) {
+          return withRenderSuggestion(
+            withHints(result, {
+              warning: codeWarnings.join(" "),
+              action:
+                "Review the flagged pattern(s) against the cognigyCodeDev skill's Code Node rules.",
             }),
             flowId,
             nodeId,
@@ -4235,12 +4261,16 @@ export class ToolHandlers {
         }
 
         const patchPayload: any = {};
+        // Hoisted out of the `if (data.config)` block below so the
+        // post-write Code Node warnings check further down (which only
+        // fires when data.config is present anyway) can still read it.
+        let nodeType = "";
         if (data.label) patchPayload.label = data.label;
         if (data.config) {
           const existingNode: any = await this.apiClient.get(
             `/v2.0/flows/${flowId}/chart/nodes/${data.nodeId}`,
           );
-          const nodeType = existingNode?.type ?? "";
+          nodeType = existingNode?.type ?? "";
 
           // Strip server-computed, read-only fields before merging them back
           // into the PATCH. `transpiled` (a code node's compiled JS) can be
@@ -4252,6 +4282,24 @@ export class ToolHandlers {
             existingConfig.mock = { ...existingConfig.mock };
             delete existingConfig.mock.transpiled;
             delete existingConfig.mock.hasError;
+          }
+
+          // Code node updates: the node's type is only known now (fetched
+          // above), so the try/catch/allowlist/HTTP standard is enforced
+          // here rather than in the schema — same rule the schema already
+          // applies on create.
+          if (nodeType === "code" && data.config.code !== undefined) {
+            const codeCheck = validateCodeNode(data.config.code);
+            if (codeCheck.errors.length > 0) {
+              return withHints(
+                {
+                  error: `Code Node update rejected: ${codeCheck.errors.join(" ")}`,
+                },
+                {
+                  action: `Update the code to match the standard try/catch shape:\n${STANDARD_CATCH_BLOCK}`,
+                },
+              );
+            }
           }
 
           // Handle case node updates — the Cognigy API expects exactly
@@ -4326,6 +4374,14 @@ export class ToolHandlers {
           ...(data.config ? { configUpdated: Object.keys(data.config) } : {}),
         };
 
+        // Code Node content warnings (non-blocking) — the hard try/catch/
+        // allowlist/HTTP checks already ran above and would have returned
+        // before the PATCH; these are the softer, non-blocking signals.
+        const codeWarnings: string[] =
+          nodeType === "code" && typeof data.config?.code === "string"
+            ? validateCodeNode(data.config.code).warnings
+            : [];
+
         // The PATCH response echoes the input config without the server-computed
         // `hasError` (transpilation runs after the write). When code was edited,
         // read the node back to detect a transpile failure and surface it.
@@ -4349,6 +4405,19 @@ export class ToolHandlers {
             // Non-fatal — the update itself succeeded.
           }
         }
+
+        if (codeWarnings.length > 0) {
+          return withRenderSuggestion(
+            withHints(result, {
+              warning: codeWarnings.join(" "),
+              action:
+                "Review the flagged pattern(s) against the cognigyCodeDev skill's Code Node rules.",
+            }),
+            flowId,
+            data.nodeId,
+          );
+        }
+
         return withRenderSuggestion(result, flowId, data.nodeId);
       }
 


### PR DESCRIPTION
## Summary

Enforces Cognigy Code Node best practices and standards at write time, rejecting non-compliant code before it reaches the platform instead of after.

In plain terms: the plugin was generating Code Nodes that could contain risky or deprecated patterns (missing error handling, deprecated functions, code that tries to do things Code Nodes shouldn't do at all). Those problems only showed up after the fact, once the code was already live. This change adds a checkpoint that catches those problems immediately, at the moment the code is written or updated, and blocks it with a clear explanation of what needs to change.

- Added a new validator (`src/tools/codeNodeValidation.ts`) that checks Code Node content against NA Professional Services standards: only approved API methods are allowed, state methods that have been removed or banned are blocked, and Code Nodes can't attempt things they aren't reliably able to do anyway (HTTP calls, module imports, browser-only APIs). It also flags a few risky-but-not-blocking patterns as warnings.
- Enforced that every Code Node wraps its logic in try/catch, using the standardized error-reporting format. Previously, a Code Node could fail partway through and the flow would just continue on as if nothing went wrong, with no record of what broke. Requiring try/catch means any failure is always caught and reported, so it shows up in the flow instead of failing silently.
- Wired this validation into the main code-creation flow (`src/schemas/tools.ts`), so both standalone Code Nodes and the pre/post-processing code on HTTP tools get checked automatically, with invalid code rejected up front and a clear error message returned.
- Extended the same protection to updates on existing Code Nodes (`src/tools/handlers.ts`). Since an update doesn't know the node's type until it looks it up, the check happens after that lookup but still before anything is saved, and the error response includes a ready-to-use template for the required error-handling format. This path also cleans up a couple of fields the server computes on its own so they don't get sent back incorrectly, and double-checks the node after saving to warn if Cognigy itself reports an error on it.
- Made small supporting updates to `src/tools/definitions.ts` and the flow-nodes Skill documentation so the new enforcement behavior is documented for anyone using the tool.
- Added `.claude/settings.json`.

## Test plan

- Updated 15 existing test fixtures (across `tools.test.ts`, `httpTool.test.ts`, and `updateTool.test.ts`) that were written before the try/catch standard existed. These were brought up to the standard using a shared helper built from the module's own standard error template - no test logic or intent was changed, just the sample code the tests use.
- Ran the full test suite: 476 tests passing, no new failures. One pre-existing, environment-dependent failure in `serverLifecycle.test.ts` reproduces the same way on unmodified `main` and is unrelated to this change.
- Type-checked cleanly (`tsc --noEmit`).
- Formatting check passed (`prettier --check`) on all changed files.
- Lint check showed no new errors (33 pre-existing, unrelated parser-config errors on test files carried over from before this change).