### PR TITLE
fix(api): tunnel Cognigy requests through corporate proxies

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -33,7 +33,7 @@ Credentials do **not** go into any `mcp_config.json` (shared, hand-edited, paste
 ## Tech stack
 
 - TypeScript, **ESM** (`"type": "module"` — import paths use `.js` even for `.ts` sources).
-- Runtime deps: `@modelcontextprotocol/sdk` (stdio transport), `axios`, `zod`, `form-data`. Nothing else.
+- Runtime deps: `@modelcontextprotocol/sdk` (stdio transport), `axios`, `zod`, `form-data`, plus `http-proxy-agent`/`https-proxy-agent`/`proxy-from-env` for corporate-proxy tunnelling (`src/utils/proxy.ts` — axios' own env-var proxy handling never issues `CONNECT`, so it cannot work behind a real proxy). Nothing else.
 - Entry `src/index.ts`: wires `Server` + `StdioServerTransport`, registers `ListTools`/`CallTool`, instantiates `CognigyApiClient` + `ToolHandlers`.
 
 ## Tools — few tools, many operations

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ A value that arrives as an unexpanded `${...}` placeholder counts as missing. Ho
 | `RATE_LIMIT_MAX_REQUESTS`           | No       | `100`   | Max requests per window                                        |
 | `RATE_LIMIT_WINDOW_MS`              | No       | `60000` | Rate limit window in ms                                        |
 | `COGNIGY_DISABLE_AUDIT_ATTRIBUTION` | No       | unset   | Set to `1` to stop naming the plugin in Cognigy's audit events |
+| `HTTPS_PROXY` / `HTTP_PROXY`        | No       | unset   | Corporate proxy to tunnel Cognigy requests through             |
+| `NO_PROXY`                          | No       | unset   | Comma-separated hosts to reach directly, bypassing the proxy   |
+| `NODE_EXTRA_CA_CERTS`               | No       | unset   | Path to your corporate root CA, for TLS-inspecting proxies     |
 
 ### Audit attribution
 
@@ -125,6 +128,24 @@ Everything this plugin changes is recorded in **Admin Center → Audit Events** 
 Requires Cognigy.AI 2026.17.0 or newer; older versions ignore the attribution and record the action normally. The "Performed by" column in the UI is gated behind the platform's `FEATURE_ENABLE_PLATFORM_AGENT_MFE` flag, but the attribution is always recorded and always readable through `list_resources { resourceType: "audit_event", actor: ["mcp-plugin"] }`.
 
 Set `COGNIGY_DISABLE_AUDIT_ATTRIBUTION=1` to opt out; plugin actions are then recorded like any other API action.
+
+### Corporate proxies
+
+If your network requires a proxy, set it in the MCP server `env` block (or export it before starting your client) and the plugin tunnels every Cognigy request through it:
+
+```json
+"env": {
+  "HTTPS_PROXY": "http://proxy.corp.example:8080",
+  "NO_PROXY": "localhost,127.0.0.1",
+  "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/corporate-root-ca.pem"
+}
+```
+
+Lower-case spellings (`https_proxy`) work too, as do credentials in the URL (`http://user:password@proxy.corp.example:8080`). HTTP and HTTPS proxies are supported; SOCKS proxies are not.
+
+**If your proxy inspects TLS** (Zscaler, Netskope, BlueCoat and similar), it presents its own certificate signed by a corporate root CA that Node does not trust by default. Point `NODE_EXTRA_CA_CERTS` at that CA file — Node reads it only at startup, so restart your client afterwards. Never set `NODE_TLS_REJECT_UNAUTHORIZED=0` instead; that disables certificate verification for every connection the engine makes.
+
+To confirm the engine picked the settings up, set `LOG_LEVEL=debug` and look for `Cognigy API requests route through a proxy` in your client's MCP log. GUI clients (Claude Desktop, Antigravity) start the engine with a minimal environment and often do not inherit your shell's proxy variables, so set them in the config file rather than your shell profile.
 
 ## Usage Examples
 

--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ A value that arrives as an unexpanded `${...}` placeholder counts as missing. Ho
 | `HTTPS_PROXY` / `HTTP_PROXY`        | No       | unset   | Corporate proxy to tunnel Cognigy requests through             |
 | `NO_PROXY`                          | No       | unset   | Comma-separated hosts to reach directly, bypassing the proxy   |
 | `NODE_EXTRA_CA_CERTS`               | No       | unset   | Path to your corporate root CA, for TLS-inspecting proxies     |
+| `COGNIGY_PROXY_CONNECT_TIMEOUT_MS`  | No       | `30000` | Deadline for reaching the proxy and completing the tunnel      |
 
 ### Audit attribution
 
@@ -142,6 +143,12 @@ If your network requires a proxy, set it in the MCP server `env` block (or expor
 ```
 
 Lower-case spellings (`https_proxy`) work too, as do credentials in the URL (`http://user:password@proxy.corp.example:8080`). HTTP and HTTPS proxies are supported; SOCKS proxies are not.
+
+The proxy is chosen per request, so `NO_PROXY` can exclude one host while another still goes through the proxy — a package download link, for example, points at wherever the platform staged the archive rather than at the API host.
+
+If a proxy is configured but cannot be used — a malformed URL, or a SOCKS proxy — requests **fail with a configuration error** rather than quietly connecting directly, which would send your API key outside the sanctioned path. Exclude the host with `NO_PROXY` if you genuinely want a direct connection.
+
+A proxy that accepts the connection and then never completes the tunnel would otherwise hang a tool call indefinitely, so connecting and negotiating is bounded at 30 seconds. Raise `COGNIGY_PROXY_CONNECT_TIMEOUT_MS` if your proxy is simply slow.
 
 **If your proxy inspects TLS** (Zscaler, Netskope, BlueCoat and similar), it presents its own certificate signed by a corporate root CA that Node does not trust by default. Point `NODE_EXTRA_CA_CERTS` at that CA file — Node reads it only at startup, so restart your client afterwards. Never set `NODE_TLS_REJECT_UNAUTHORIZED=0` instead; that disables certificate verification for every connection the engine makes.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,9 @@
         "@modelcontextprotocol/sdk": "1.27.1",
         "axios": "1.13.6",
         "form-data": "4.0.5",
+        "http-proxy-agent": "9.1.0",
+        "https-proxy-agent": "9.1.0",
+        "proxy-from-env": "1.1.0",
         "zod": "3.25.76"
       },
       "bin": {
@@ -3890,7 +3893,6 @@
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
       "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
@@ -7195,7 +7197,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-9.1.0.tgz",
       "integrity": "sha512-2NxoveTT58mjYT4n3RPTEfCZGLMbidoO8XEieXfpSYxu+PQJ1qpx4ypwH6N+uF9twBPIvRRgvkvW5HUTYWENig==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "9.0.0",
@@ -7210,7 +7211,6 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
       "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "9.0.0",
@@ -11702,7 +11702,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
       "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"

--- a/package.json
+++ b/package.json
@@ -48,6 +48,9 @@
     "@modelcontextprotocol/sdk": "1.27.1",
     "axios": "1.13.6",
     "form-data": "4.0.5",
+    "http-proxy-agent": "9.1.0",
+    "https-proxy-agent": "9.1.0",
+    "proxy-from-env": "1.1.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/plugin/skills/troubleshooting/SKILL.md
+++ b/plugin/skills/troubleshooting/SKILL.md
@@ -54,8 +54,15 @@ Cognigy.
 - If the proxy inspects TLS, also set `NODE_EXTRA_CA_CERTS` to the corporate root
   CA file, then restart the client — Node reads it only at startup. Do not set
   `NODE_TLS_REJECT_UNAUTHORIZED=0`.
-- An error mentioning a proxy, or quoting an HTML body, came from the proxy
-  rather than from Cognigy; the quoted text is the proxy's own message.
+- An error quoting an HTML body, or naming a proxy, points at the proxy rather
+  than Cognigy; the quoted text is the proxy's own message.
+- "Cannot use the configured proxy ..." means the proxy setting itself is
+  malformed or unsupported (SOCKS proxies are not supported). Requests fail
+  instead of connecting directly, so the API key never leaves the sanctioned
+  path; exclude the host with `NO_PROXY` if a direct connection is intended.
+- "Timed out ... connecting through the proxy" means the proxy accepted the
+  connection but never completed the tunnel. Check the proxy address, or raise
+  `COGNIGY_PROXY_CONNECT_TIMEOUT_MS` (default 30000) if it is merely slow.
 - `LOG_LEVEL=debug` logs the proxy actually in use at startup.
 
 ## setup_llm fails

--- a/plugin/skills/troubleshooting/SKILL.md
+++ b/plugin/skills/troubleshooting/SKILL.md
@@ -42,6 +42,22 @@ description: "Use when a Cognigy agent returns empty responses, a tool call or c
   list_resources { resourceType: "project", sort: "lastChanged:desc", limit: 5 }
 - `sort` takes `field:direction` and works on any field the resource returns.
 
+## Every tool call fails with the same error, but the tool list works
+
+Suspect the network path, not the platform — listing tools makes no HTTP request,
+so a working list plus a uniformly failing call means requests are not reaching
+Cognigy.
+
+- On a corporate network, set `HTTPS_PROXY` (and `NO_PROXY` for hosts to reach
+  directly) in the MCP server `env` block. GUI clients start the engine with a
+  minimal environment and usually do not inherit shell proxy variables.
+- If the proxy inspects TLS, also set `NODE_EXTRA_CA_CERTS` to the corporate root
+  CA file, then restart the client — Node reads it only at startup. Do not set
+  `NODE_TLS_REJECT_UNAUTHORIZED=0`.
+- An error mentioning a proxy, or quoting an HTML body, came from the proxy
+  rather than from Cognigy; the quoted text is the proxy's own message.
+- `LOG_LEVEL=debug` logs the proxy actually in use at startup.
+
 ## setup_llm fails
 
 - See the llm-providers skill for valid provider and model strings

--- a/src/__tests__/apiErrorMessages.test.ts
+++ b/src/__tests__/apiErrorMessages.test.ts
@@ -69,6 +69,14 @@ describe("describeUnexpectedBody", () => {
     expect(message).toContain("…");
   });
 
+  it("caps a multi-megabyte body without building the whole string", () => {
+    const message = describeUnexpectedBody(
+      Buffer.alloc(5 * 1024 * 1024, "y"),
+      errorWith(502),
+    );
+    expect(message.length).toBeLessThan(600);
+  });
+
   it("names the proxy when one is configured for the request", () => {
     process.env.HTTPS_PROXY = "http://alice:s3cret@proxy.corp.example:8080";
     const message = describeUnexpectedBody(

--- a/src/__tests__/apiErrorMessages.test.ts
+++ b/src/__tests__/apiErrorMessages.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Tests for the error message produced when a response body is not a Cognigy
+ * error. Behind a corporate proxy this is the common case — the proxy answers
+ * with an HTML page — and the message used to collapse to a bare
+ * "API request failed", hiding what actually responded.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import type { AxiosError } from "axios";
+import { describeUnexpectedBody } from "../api/client.js";
+
+const PROXY_ENV_VARS = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+];
+
+function errorWith(status: number, url = "/v2.0/projects"): AxiosError {
+  return {
+    config: { url, baseURL: "https://api-trial.cognigy.ai" },
+    response: { status },
+  } as unknown as AxiosError;
+}
+
+describe("describeUnexpectedBody", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of PROXY_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of PROXY_ENV_VARS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+  });
+
+  it("includes the status and a snippet of an HTML body", () => {
+    const message = describeUnexpectedBody(
+      "<html>\n  <body>\n    ERROR: The requested URL could not be retrieved\n  </body>\n</html>",
+      errorWith(500),
+    );
+    expect(message).toContain("HTTP 500");
+    expect(message).toContain("The requested URL could not be retrieved");
+    // Whitespace collapsed so the snippet budget holds real text.
+    expect(message).not.toContain("\n");
+  });
+
+  it("serialises a non-Cognigy JSON body", () => {
+    const message = describeUnexpectedBody(
+      { message: "Forbidden by policy" },
+      errorWith(403),
+    );
+    expect(message).toContain("Forbidden by policy");
+  });
+
+  it("truncates a long body", () => {
+    const message = describeUnexpectedBody("x".repeat(5000), errorWith(502));
+    expect(message.length).toBeLessThan(600);
+    expect(message).toContain("…");
+  });
+
+  it("names the proxy when one is configured for the request", () => {
+    process.env.HTTPS_PROXY = "http://alice:s3cret@proxy.corp.example:8080";
+    const message = describeUnexpectedBody(
+      "<html>denied</html>",
+      errorWith(500),
+    );
+    expect(message).toContain("proxy.corp.example:8080");
+    expect(message).not.toContain("s3cret");
+    expect(message).toContain("NODE_EXTRA_CA_CERTS");
+  });
+
+  it("does not mention a proxy when NO_PROXY excludes the host", () => {
+    process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+    process.env.NO_PROXY = "api-trial.cognigy.ai";
+    const message = describeUnexpectedBody(
+      "<html>denied</html>",
+      errorWith(500),
+    );
+    expect(message).not.toContain("proxy.corp.example");
+  });
+
+  it("does not mention a proxy when none is configured", () => {
+    const message = describeUnexpectedBody(
+      "<html>denied</html>",
+      errorWith(500),
+    );
+    expect(message).not.toContain("proxy");
+  });
+
+  it("survives a request config with no usable URL", () => {
+    const error = { response: { status: 500 } } as unknown as AxiosError;
+    expect(() => describeUnexpectedBody("boom", error)).not.toThrow();
+  });
+
+  it("handles a Buffer body", () => {
+    const message = describeUnexpectedBody(
+      Buffer.from("proxy authentication required"),
+      errorWith(407),
+    );
+    expect(message).toContain("proxy authentication required");
+  });
+});

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -12,10 +12,12 @@ import { HttpsProxyAgent } from "https-proxy-agent";
 import {
   clearProxyAgentCache,
   getProxyAxiosOptions,
+  ProxyConfigurationError,
   redactProxyUrl,
 } from "../utils/proxy.js";
 
 const PROXY_ENV_VARS = [
+  "COGNIGY_PROXY_CONNECT_TIMEOUT_MS",
   "HTTP_PROXY",
   "http_proxy",
   "HTTPS_PROXY",
@@ -117,19 +119,33 @@ describe("proxy support", () => {
       expect(second.httpsAgent).toBe(first.httpsAgent);
     });
 
-    it("falls back to a direct connection when the proxy URL is unusable", () => {
+    it("refuses an unusable proxy URL instead of connecting directly", () => {
       // A bare scheme survives proxy-from-env's normalisation but has no host.
       process.env.HTTPS_PROXY = "http://";
-      const options = getProxyAxiosOptions(API_URL);
-      expect(options.proxy).toBe(false);
-      expect(options.httpsAgent).toBeUndefined();
+      expect(() => getProxyAxiosOptions(API_URL)).toThrow(
+        ProxyConfigurationError,
+      );
     });
 
-    it("refuses a SOCKS proxy rather than tunnelling to a nonsense host", () => {
+    it("refuses a SOCKS proxy rather than silently bypassing it", () => {
       process.env.HTTPS_PROXY = "socks5://proxy.corp.example:1080";
-      const options = getProxyAxiosOptions(API_URL);
-      expect(options.proxy).toBe(false);
-      expect(options.httpsAgent).toBeUndefined();
+      expect(() => getProxyAxiosOptions(API_URL)).toThrow(
+        /only http and https proxies are supported/,
+      );
+    });
+
+    it("names NO_PROXY as the way out in the rejection message", () => {
+      process.env.HTTPS_PROXY = "socks5://proxy.corp.example:1080";
+      expect(() => getProxyAxiosOptions(API_URL)).toThrow(/NO_PROXY/);
+    });
+
+    it("keeps proxy credentials out of the rejection message", () => {
+      process.env.HTTPS_PROXY = "socks5://alice:s3cret@proxy.corp.example:1080";
+      expect(() => getProxyAxiosOptions(API_URL)).toThrow(
+        expect.objectContaining({
+          message: expect.not.stringContaining("s3cret"),
+        }) as Error,
+      );
     });
 
     it("accepts an https:// proxy URL", () => {

--- a/src/__tests__/proxy.test.ts
+++ b/src/__tests__/proxy.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for corporate-proxy support.
+ *
+ * The behaviour under test is the axios wiring, not the tunnelling itself:
+ * every instance must carry `proxy: false` (axios' own proxy handling sends a
+ * plaintext absolute-form request that corporate proxies reject) and, when a
+ * proxy applies, real tunnelling agents.
+ */
+import { describe, it, expect, beforeEach, afterEach } from "@jest/globals";
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import {
+  clearProxyAgentCache,
+  getProxyAxiosOptions,
+  redactProxyUrl,
+} from "../utils/proxy.js";
+
+const PROXY_ENV_VARS = [
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+  "npm_config_proxy",
+  "npm_config_https_proxy",
+];
+
+const API_URL = "https://api-trial.cognigy.ai";
+
+describe("proxy support", () => {
+  let savedEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of PROXY_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    clearProxyAgentCache();
+  });
+
+  afterEach(() => {
+    for (const key of PROXY_ENV_VARS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    clearProxyAgentCache();
+  });
+
+  describe("getProxyAxiosOptions", () => {
+    it("always disables axios' own proxy handling", () => {
+      expect(getProxyAxiosOptions(API_URL).proxy).toBe(false);
+
+      process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+      expect(getProxyAxiosOptions(API_URL).proxy).toBe(false);
+    });
+
+    it("attaches no agents when no proxy is configured", () => {
+      const options = getProxyAxiosOptions(API_URL);
+      expect(options.httpAgent).toBeUndefined();
+      expect(options.httpsAgent).toBeUndefined();
+    });
+
+    it("attaches tunnelling agents when HTTPS_PROXY is set", () => {
+      process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+      const options = getProxyAxiosOptions(API_URL);
+      expect(options.httpsAgent).toBeInstanceOf(HttpsProxyAgent);
+      expect(options.httpAgent).toBeInstanceOf(HttpProxyAgent);
+    });
+
+    it("reads the lower-case variable spelling too", () => {
+      process.env.https_proxy = "http://proxy.corp.example:8080";
+      expect(getProxyAxiosOptions(API_URL).httpsAgent).toBeInstanceOf(
+        HttpsProxyAgent,
+      );
+    });
+
+    it("uses HTTP_PROXY for an http:// target", () => {
+      process.env.HTTP_PROXY = "http://proxy.corp.example:8080";
+      const options = getProxyAxiosOptions("http://cognigy.internal");
+      expect(options.httpAgent).toBeInstanceOf(HttpProxyAgent);
+    });
+
+    it("honours NO_PROXY exclusions", () => {
+      process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+      process.env.NO_PROXY = "api-trial.cognigy.ai";
+      const options = getProxyAxiosOptions(API_URL);
+      expect(options.httpsAgent).toBeUndefined();
+      expect(options.httpAgent).toBeUndefined();
+    });
+
+    it("keeps proxying hosts NO_PROXY does not cover", () => {
+      process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+      process.env.NO_PROXY = "internal.example";
+      expect(getProxyAxiosOptions(API_URL).httpsAgent).toBeInstanceOf(
+        HttpsProxyAgent,
+      );
+    });
+
+    it("passes proxy credentials through to the agent", () => {
+      process.env.HTTPS_PROXY = "http://alice:s3cret@proxy.corp.example:8080";
+      const agent = getProxyAxiosOptions(API_URL).httpsAgent as HttpsProxyAgent<
+        typeof API_URL
+      >;
+      expect(agent).toBeInstanceOf(HttpsProxyAgent);
+      expect(agent.proxy.username).toBe("alice");
+      expect(agent.proxy.password).toBe("s3cret");
+    });
+
+    it("reuses one agent per proxy so sockets are pooled", () => {
+      process.env.HTTPS_PROXY = "http://proxy.corp.example:8080";
+      const first = getProxyAxiosOptions(API_URL);
+      const second = getProxyAxiosOptions(`${API_URL}/v2.0/projects`);
+      expect(second.httpsAgent).toBe(first.httpsAgent);
+    });
+
+    it("falls back to a direct connection when the proxy URL is unusable", () => {
+      // A bare scheme survives proxy-from-env's normalisation but has no host.
+      process.env.HTTPS_PROXY = "http://";
+      const options = getProxyAxiosOptions(API_URL);
+      expect(options.proxy).toBe(false);
+      expect(options.httpsAgent).toBeUndefined();
+    });
+
+    it("refuses a SOCKS proxy rather than tunnelling to a nonsense host", () => {
+      process.env.HTTPS_PROXY = "socks5://proxy.corp.example:1080";
+      const options = getProxyAxiosOptions(API_URL);
+      expect(options.proxy).toBe(false);
+      expect(options.httpsAgent).toBeUndefined();
+    });
+
+    it("accepts an https:// proxy URL", () => {
+      process.env.HTTPS_PROXY = "https://proxy.corp.example:8443";
+      expect(getProxyAxiosOptions(API_URL).httpsAgent).toBeInstanceOf(
+        HttpsProxyAgent,
+      );
+    });
+  });
+
+  describe("redactProxyUrl", () => {
+    it("removes credentials", () => {
+      const redacted = redactProxyUrl(
+        "http://alice:s3cret@proxy.corp.example:8080",
+      );
+      expect(redacted).not.toContain("s3cret");
+      expect(redacted).not.toContain("alice");
+      expect(redacted).toContain("proxy.corp.example:8080");
+    });
+
+    it("leaves a credential-free URL usable", () => {
+      expect(redactProxyUrl("http://proxy.corp.example:8080")).toContain(
+        "proxy.corp.example:8080",
+      );
+    });
+
+    it("does not throw on an unparseable value", () => {
+      expect(redactProxyUrl("not-a-url")).toBe("(unparseable proxy url)");
+    });
+  });
+});

--- a/src/__tests__/proxyRouting.test.ts
+++ b/src/__tests__/proxyRouting.test.ts
@@ -149,6 +149,88 @@ describe("proxy routing (real sockets)", () => {
     expect(proxied).toEqual([downloadUrl]);
   });
 
+  it("routes a redirect destination that needs the proxy, even when the first hop did not", async () => {
+    // Redirects are followed inside axios' transport, which never re-enters
+    // the request interceptor: without a per-hop decision the second request
+    // keeps the first hop's (direct) route.
+    const origin = await listen(
+      createServer((req, res) => {
+        res.writeHead(302, {
+          Location: `http://localhost:${portOf(origin)}/download/archive.zip`,
+        });
+        res.end();
+      }),
+    );
+
+    const proxied: string[] = [];
+    const proxy = await listen(
+      createServer((req, res) => {
+        proxied.push(req.url ?? "");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ via: "proxy" }));
+      }),
+    );
+
+    process.env.HTTP_PROXY = `http://127.0.0.1:${portOf(proxy)}`;
+    process.env.NO_PROXY = "127.0.0.1";
+
+    const client = new CognigyApiClient({
+      baseUrl: `http://127.0.0.1:${portOf(origin)}`,
+      apiKey: "test-key",
+    });
+
+    // First hop is excluded by NO_PROXY and goes direct; the redirect target
+    // is not excluded, so that hop must be tunnelled.
+    await expect(client.get("/v2.0/packages/link")).resolves.toEqual({
+      via: "proxy",
+    });
+    expect(proxied).toEqual([
+      `http://localhost:${portOf(origin)}/download/archive.zip`,
+    ]);
+  });
+
+  it("stops proxying after a redirect to a host NO_PROXY excludes", async () => {
+    const directHits: string[] = [];
+    const origin = await listen(
+      createServer((req, res) => {
+        directHits.push(req.url ?? "");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ via: "origin" }));
+      }),
+    );
+
+    const proxied: string[] = [];
+    const proxy = await listen(
+      createServer((req, res) => {
+        proxied.push(req.url ?? "");
+        res.writeHead(302, {
+          Location: `http://127.0.0.1:${portOf(origin)}/download/archive.zip`,
+        });
+        res.end();
+      }),
+    );
+
+    process.env.HTTP_PROXY = `http://127.0.0.1:${portOf(proxy)}`;
+    process.env.NO_PROXY = "127.0.0.1";
+
+    const client = new CognigyApiClient({
+      baseUrl: `http://127.0.0.1:${portOf(origin)}`,
+      apiKey: "test-key",
+    });
+
+    // The first hop is proxied; its redirect lands on an excluded host, which
+    // must clear the proxy agent rather than keep tunnelling.
+    await expect(
+      client.get(`http://localhost:${portOf(origin)}/v2.0/packages/link`, {
+        baseURL: undefined,
+      }),
+    ).resolves.toEqual({ via: "origin" });
+    expect(proxied).toEqual([
+      `http://localhost:${portOf(origin)}/v2.0/packages/link`,
+    ]);
+    expect(directHits).toEqual(["/download/archive.zip"]);
+  });
+
   it("fails the request when the configured proxy is unusable", async () => {
     process.env.HTTPS_PROXY = "socks5://127.0.0.1:1080";
     const client = new CognigyApiClient({

--- a/src/__tests__/proxyRouting.test.ts
+++ b/src/__tests__/proxyRouting.test.ts
@@ -1,0 +1,163 @@
+/**
+ * End-to-end tests for proxy routing against real loopback servers: the
+ * `CONNECT` deadline, and per-request proxy selection.
+ *
+ * These need real sockets — the behaviours under test live in the connection
+ * phase, which a mocked adapter never reaches.
+ */
+import {
+  describe,
+  it,
+  expect,
+  beforeEach,
+  afterEach,
+  jest,
+} from "@jest/globals";
+import axios from "axios";
+import { createServer, type Server } from "http";
+import { createServer as createTcpServer, type Server as TcpServer } from "net";
+import { AddressInfo } from "net";
+import { CognigyApiClient } from "../api/client.js";
+import { clearProxyAgentCache, getProxyAxiosOptions } from "../utils/proxy.js";
+
+const PROXY_ENV_VARS = [
+  "COGNIGY_PROXY_CONNECT_TIMEOUT_MS",
+  "HTTP_PROXY",
+  "http_proxy",
+  "HTTPS_PROXY",
+  "https_proxy",
+  "ALL_PROXY",
+  "all_proxy",
+  "NO_PROXY",
+  "no_proxy",
+];
+
+function portOf(server: Server | TcpServer): number {
+  return (server.address() as AddressInfo).port;
+}
+
+describe("proxy routing (real sockets)", () => {
+  let savedEnv: Record<string, string | undefined>;
+  const closers: Array<() => Promise<void>> = [];
+
+  beforeEach(() => {
+    savedEnv = {};
+    for (const key of PROXY_ENV_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+    clearProxyAgentCache();
+  });
+
+  afterEach(async () => {
+    for (const close of closers.splice(0)) await close();
+    for (const key of PROXY_ENV_VARS) {
+      if (savedEnv[key] === undefined) delete process.env[key];
+      else process.env[key] = savedEnv[key];
+    }
+    clearProxyAgentCache();
+  });
+
+  function track(server: Server | TcpServer) {
+    closers.push(
+      () =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+    );
+  }
+
+  async function listen<T extends Server | TcpServer>(server: T): Promise<T> {
+    await new Promise<void>((resolve) =>
+      server.listen(0, "127.0.0.1", resolve),
+    );
+    track(server);
+    return server;
+  }
+
+  it("fails a request when the proxy accepts the connection but never completes the tunnel", async () => {
+    // A proxy that accepts TCP and then goes silent. Axios' own `timeout`
+    // cannot catch this: it is armed once the request has a socket, and a
+    // proxy agent hands the socket over only after the tunnel is negotiated.
+    const stalled = await listen(
+      createTcpServer((socket) => {
+        socket.on("data", () => {
+          /* read the CONNECT request and never answer it */
+        });
+      }),
+    );
+
+    process.env.HTTPS_PROXY = `http://127.0.0.1:${portOf(stalled)}`;
+    process.env.COGNIGY_PROXY_CONNECT_TIMEOUT_MS = "200";
+
+    const target = "https://cognigy.invalid";
+    const client = axios.create({
+      // A timeout far longer than the deadline: if the request only fails when
+      // this fires, the deadline did not do its job.
+      timeout: 30000,
+      ...getProxyAxiosOptions(target),
+    });
+
+    const started = Date.now();
+    await expect(client.get(target)).rejects.toMatchObject({
+      code: "ETIMEDOUT",
+    });
+    expect(Date.now() - started).toBeLessThan(5000);
+  });
+
+  it("selects the proxy per request, not per client", async () => {
+    // 127.0.0.1 and localhost are the same address but different hostnames, so
+    // NO_PROXY can cover one and not the other — which is exactly the shape of
+    // an API host that bypasses the proxy while a package download link does
+    // not (downloadPackageArchive sends an absolute URL with baseURL: undefined).
+    const origin = await listen(
+      createServer((_req, res) => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ via: "origin" }));
+      }),
+    );
+
+    const proxied: string[] = [];
+    const proxy = await listen(
+      createServer((req, res) => {
+        proxied.push(req.url ?? "");
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ via: "proxy" }));
+      }),
+    );
+
+    process.env.HTTP_PROXY = `http://127.0.0.1:${portOf(proxy)}`;
+    process.env.NO_PROXY = "127.0.0.1";
+
+    const client = new CognigyApiClient({
+      baseUrl: `http://127.0.0.1:${portOf(origin)}`,
+      apiKey: "test-key",
+    });
+
+    // Excluded by NO_PROXY: must reach the origin directly.
+    await expect(client.get("/v2.0/projects")).resolves.toEqual({
+      via: "origin",
+    });
+    expect(proxied).toHaveLength(0);
+
+    // Same client, absolute URL on a host NO_PROXY does not cover: must be
+    // proxied even though the client's own base URL is excluded.
+    const downloadUrl = `http://localhost:${portOf(origin)}/download/archive.zip`;
+    await expect(
+      client.get(downloadUrl, { baseURL: undefined }),
+    ).resolves.toEqual({ via: "proxy" });
+    expect(proxied).toEqual([downloadUrl]);
+  });
+
+  it("fails the request when the configured proxy is unusable", async () => {
+    process.env.HTTPS_PROXY = "socks5://127.0.0.1:1080";
+    const client = new CognigyApiClient({
+      baseUrl: "https://api-trial.cognigy.ai",
+      apiKey: "test-key",
+    });
+
+    await expect(client.get("/v2.0/projects")).rejects.toThrow(
+      /only http and https proxies are supported/,
+    );
+  });
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,7 +7,11 @@ import axios, {
 } from "axios";
 import FormData from "form-data";
 import { logger } from "../utils/logger.js";
-import { getProxyAxiosOptions, redactProxyUrl } from "../utils/proxy.js";
+import {
+  applyProxyToRedirect,
+  getProxyAxiosOptions,
+  redactProxyUrl,
+} from "../utils/proxy.js";
 import { getProxyForUrl } from "proxy-from-env";
 import {
   ACTOR_CONTEXT_HEADER,
@@ -172,6 +176,9 @@ export class CognigyApiClient {
           reqConfig,
           getProxyAxiosOptions(resolveRequestUrl(reqConfig)),
         );
+        // Redirects are followed inside the transport, below this interceptor,
+        // so each hop re-resolves its own route from its own destination.
+        reqConfig.beforeRedirect = applyProxyToRedirect;
         // Attribute this write to the plugin in Cognigy's audit events. Set
         // here rather than per call site so every platform request is covered,
         // including uploadFile's own headers object. Absent outside a tool

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -100,7 +100,7 @@ export function describeUnexpectedBody(
     message += `: the response did not match the expected Cognigy error format — ${snippet}`;
   }
 
-  const proxyUrl = safeGetProxyForUrl(resolveRequestUrl(error));
+  const proxyUrl = safeGetProxyForUrl(resolveRequestUrl(error.config));
   if (proxyUrl) {
     message +=
       ` This request went through the proxy ${redactProxyUrl(proxyUrl)};` +
@@ -113,13 +113,15 @@ export function describeUnexpectedBody(
 }
 
 /**
- * Best-effort absolute URL for the failed request. Request paths are relative
- * to the client's `baseURL`, and `getProxyForUrl` needs an absolute URL to
- * apply `NO_PROXY` — but neither field is guaranteed to be present or valid,
- * and an error path must never throw an error of its own.
+ * Best-effort absolute URL for a request. Request paths are usually relative to
+ * the client's `baseURL`, and `getProxyForUrl` needs an absolute URL to apply
+ * `NO_PROXY` — but neither field is guaranteed to be present or valid, and
+ * neither proxy selection nor the error path may throw an error of its own.
  */
-function resolveRequestUrl(error: AxiosError): string {
-  const { url, baseURL } = error.config ?? {};
+function resolveRequestUrl(
+  config: Pick<AxiosRequestConfig, "url" | "baseURL"> | undefined,
+): string {
+  const { url, baseURL } = config ?? {};
   try {
     if (url) return new URL(url, baseURL).toString();
   } catch {
@@ -152,14 +154,24 @@ export class CognigyApiClient {
         Accept: "application/json",
       },
       timeout: 30000,
-      // Every request to the platform shares one base URL, so the proxy (and
-      // any NO_PROXY exclusion) is resolved once here rather than per call.
-      ...getProxyAxiosOptions(config.baseUrl),
+      // Axios' own proxy handling never opens a CONNECT tunnel; the request
+      // interceptor below attaches real tunnelling agents instead.
+      proxy: false,
     });
 
     this.client.interceptors.request.use(
       (reqConfig) => {
         reqConfig.headers["X-API-Key"] = this.apiKey;
+        // Resolve the proxy against THIS request's target rather than the
+        // client's base URL. Not every request goes to the API host:
+        // downloadPackageArchive passes an absolute download link with
+        // `baseURL: undefined`, and that host has its own NO_PROXY standing —
+        // a client-wide decision would proxy it when it should not, or send it
+        // direct when the proxy is mandatory.
+        Object.assign(
+          reqConfig,
+          getProxyAxiosOptions(resolveRequestUrl(reqConfig)),
+        );
         // Attribute this write to the plugin in Cognigy's audit events. Set
         // here rather than per call site so every platform request is covered,
         // including uploadFile's own headers object. Absent outside a tool

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -7,6 +7,8 @@ import axios, {
 } from "axios";
 import FormData from "form-data";
 import { logger } from "../utils/logger.js";
+import { getProxyAxiosOptions, redactProxyUrl } from "../utils/proxy.js";
+import { getProxyForUrl } from "proxy-from-env";
 import {
   ACTOR_CONTEXT_HEADER,
   getActorContextHeader,
@@ -44,6 +46,88 @@ function isRetryable(error: AxiosError): boolean {
   return RETRYABLE_NETWORK_CODES.has(error.code ?? "");
 }
 
+const BODY_SNIPPET_LIMIT = 300;
+
+/**
+ * Build the message for a response that came back with a body Cognigy would
+ * never send — no `detail`, no `title`. This used to collapse to a bare
+ * "API request failed", which threw away the only evidence of what actually
+ * answered: in the corporate-proxy case the responder is the proxy, returning
+ * an HTML error page, and the generic message made that indistinguishable from
+ * a platform outage. Include a trimmed snippet, and name the proxy when one is
+ * in play so the next report arrives already diagnosed.
+ *
+ * Exported for tests; not part of the client's public surface.
+ */
+export function describeUnexpectedBody(
+  data: unknown,
+  error: AxiosError,
+): string {
+  let snippet: string;
+  if (typeof data === "string") {
+    snippet = data;
+  } else if (Buffer.isBuffer(data)) {
+    snippet = data.toString("utf8");
+  } else {
+    try {
+      snippet = JSON.stringify(data);
+    } catch {
+      snippet = String(data);
+    }
+  }
+  // Collapse whitespace: HTML error pages are mostly newlines and indentation,
+  // which would otherwise eat the snippet budget before the useful text.
+  snippet = snippet.replace(/\s+/g, " ").trim();
+  if (snippet.length > BODY_SNIPPET_LIMIT) {
+    snippet = `${snippet.slice(0, BODY_SNIPPET_LIMIT)}…`;
+  }
+
+  const parts = ["API request failed"];
+  const status = error.response?.status;
+  if (status) parts.push(`(HTTP ${status})`);
+
+  let message = parts.join(" ");
+  if (snippet) {
+    message += `: the response did not come from the Cognigy API — ${snippet}`;
+  }
+
+  const proxyUrl = safeGetProxyForUrl(resolveRequestUrl(error));
+  if (proxyUrl) {
+    message +=
+      ` This request went through the proxy ${redactProxyUrl(proxyUrl)};` +
+      ` the proxy, not Cognigy, may have produced this response.` +
+      ` If the proxy inspects TLS, set NODE_EXTRA_CA_CERTS to your corporate` +
+      ` root CA file.`;
+  }
+
+  return message;
+}
+
+/**
+ * Best-effort absolute URL for the failed request. Request paths are relative
+ * to the client's `baseURL`, and `getProxyForUrl` needs an absolute URL to
+ * apply `NO_PROXY` — but neither field is guaranteed to be present or valid,
+ * and an error path must never throw an error of its own.
+ */
+function resolveRequestUrl(error: AxiosError): string {
+  const { url, baseURL } = error.config ?? {};
+  try {
+    if (url) return new URL(url, baseURL).toString();
+  } catch {
+    // Fall through to the base URL below.
+  }
+  return baseURL ?? "";
+}
+
+function safeGetProxyForUrl(targetUrl: string): string {
+  if (!targetUrl) return "";
+  try {
+    return getProxyForUrl(targetUrl);
+  } catch {
+    return "";
+  }
+}
+
 export class CognigyApiClient {
   private client: AxiosInstance;
   private apiKey: string;
@@ -59,6 +143,9 @@ export class CognigyApiClient {
         Accept: "application/json",
       },
       timeout: 30000,
+      // Every request to the platform shares one base URL, so the proxy (and
+      // any NO_PROXY exclusion) is resolved once here rather than per call.
+      ...getProxyAxiosOptions(config.baseUrl),
     });
 
     this.client.interceptors.request.use(
@@ -130,7 +217,8 @@ export class CognigyApiClient {
   private formatError(error: AxiosError): Error {
     const data = error.response?.data as any;
     if (data) {
-      const message = data.detail || data.title || "API request failed";
+      const message =
+        data.detail || data.title || describeUnexpectedBody(data, error);
       const enhancedError = new Error(message);
       (enhancedError as any).status = data.status || error.response?.status;
       (enhancedError as any).code = data.code;

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -47,10 +47,12 @@ function isRetryable(error: AxiosError): boolean {
 }
 
 const BODY_SNIPPET_LIMIT = 300;
+/** How much of the raw body is read before whitespace collapsing. */
+const RAW_BODY_READ_LIMIT = BODY_SNIPPET_LIMIT * 20;
 
 /**
- * Build the message for a response that came back with a body Cognigy would
- * never send — no `detail`, no `title`. This used to collapse to a bare
+ * Build the message for a response whose body carries neither `detail` nor
+ * `title`, i.e. is not a Cognigy error. This used to collapse to a bare
  * "API request failed", which threw away the only evidence of what actually
  * answered: in the corporate-proxy case the responder is the proxy, returning
  * an HTML error page, and the generic message made that indistinguishable from
@@ -63,16 +65,23 @@ export function describeUnexpectedBody(
   data: unknown,
   error: AxiosError,
 ): string {
+  // Cap before decoding or collapsing whitespace: an error path must not
+  // allocate a multi-megabyte string just to throw all but 300 characters of it
+  // away. The raw cap is deliberately generous — whitespace collapsing shrinks
+  // an HTML page a lot, so slicing at the final limit would leave the snippet
+  // short of real text.
   let snippet: string;
   if (typeof data === "string") {
-    snippet = data;
+    snippet = data.slice(0, RAW_BODY_READ_LIMIT);
   } else if (Buffer.isBuffer(data)) {
-    snippet = data.toString("utf8");
+    // Slicing bytes can cut a multi-byte character in half; the trailing
+    // replacement char is acceptable in a truncated diagnostic snippet.
+    snippet = data.subarray(0, RAW_BODY_READ_LIMIT).toString("utf8");
   } else {
     try {
-      snippet = JSON.stringify(data);
+      snippet = JSON.stringify(data)?.slice(0, RAW_BODY_READ_LIMIT) ?? "";
     } catch {
-      snippet = String(data);
+      snippet = String(data).slice(0, RAW_BODY_READ_LIMIT);
     }
   }
   // Collapse whitespace: HTML error pages are mostly newlines and indentation,
@@ -88,7 +97,7 @@ export function describeUnexpectedBody(
 
   let message = parts.join(" ");
   if (snippet) {
-    message += `: the response did not come from the Cognigy API — ${snippet}`;
+    message += `: the response did not match the expected Cognigy error format — ${snippet}`;
   }
 
   const proxyUrl = safeGetProxyForUrl(resolveRequestUrl(error));

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { SERVER_INSTRUCTIONS } from "./instructions.js";
 import { logger } from "./utils/logger.js";
 import { RateLimiter } from "./utils/rateLimiter.js";
 import { getSessionId, getTaskId, runWithTask } from "./utils/actorContext.js";
+import { logProxyConfiguration } from "./utils/proxy.js";
 
 async function main() {
   try {
@@ -24,6 +25,7 @@ async function main() {
       name: config.serverName,
       version: config.serverVersion,
     });
+    logProxyConfiguration(config.apiBaseUrl);
 
     const apiClient = new CognigyApiClient({
       baseUrl: config.apiBaseUrl,

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -14,6 +14,7 @@ import { basename, dirname, isAbsolute, join } from "path";
 import { randomUUID } from "crypto";
 import { pathToFileURL } from "url";
 import axios from "axios";
+import { getProxyAxiosOptions } from "../utils/proxy.js";
 import { CognigyApiClient } from "../api/client.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -2323,6 +2324,11 @@ export class ToolHandlers {
           Accept: "application/json",
         },
         timeout: 30000,
+        // Endpoint traffic does not go through CognigyApiClient, so it needs
+        // the proxy wiring of its own. Resolved per call rather than cached:
+        // the endpoint host differs from the API host and may be excluded by
+        // NO_PROXY independently.
+        ...getProxyAxiosOptions(endpointUrl!),
       });
 
       let agentResponse = response.data.text || "";

--- a/src/tools/handlers.ts
+++ b/src/tools/handlers.ts
@@ -14,7 +14,7 @@ import { basename, dirname, isAbsolute, join } from "path";
 import { randomUUID } from "crypto";
 import { pathToFileURL } from "url";
 import axios from "axios";
-import { getProxyAxiosOptions } from "../utils/proxy.js";
+import { applyProxyToRedirect, getProxyAxiosOptions } from "../utils/proxy.js";
 import { CognigyApiClient } from "../api/client.js";
 import { logger } from "../utils/logger.js";
 import {
@@ -2329,6 +2329,7 @@ export class ToolHandlers {
         // the endpoint host differs from the API host and may be excluded by
         // NO_PROXY independently.
         ...getProxyAxiosOptions(endpointUrl!),
+        beforeRedirect: applyProxyToRedirect,
       });
 
       let agentResponse = response.data.text || "";

--- a/src/types/proxy-from-env.d.ts
+++ b/src/types/proxy-from-env.d.ts
@@ -1,0 +1,14 @@
+/**
+ * `proxy-from-env` ships no types and has no `@types/` package. It is already
+ * in the tree as axios' own dependency; declaring the one function we use here
+ * keeps it that way instead of adding a dev dependency for four lines.
+ */
+declare module "proxy-from-env" {
+  /**
+   * Returns the proxy URL configured for `url` via the environment
+   * (`HTTP_PROXY`/`HTTPS_PROXY`/`ALL_PROXY`/`NPM_CONFIG_*`, in either case),
+   * or an empty string when none applies — including when `NO_PROXY` excludes
+   * the target.
+   */
+  export function getProxyForUrl(url: string): string;
+}

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -54,6 +54,20 @@ function getAgents(proxyUrl: string): { http: Agent; https: Agent } {
 }
 
 /**
+ * Origin only — never the path. `talk_to_agent` resolves through here with an
+ * endpoint URL whose path is the `URLToken`, which anyone holding it can use to
+ * talk to the agent. Logs get pasted into bug reports, so the host is all a
+ * proxy diagnosis needs and all it may have.
+ */
+function targetOrigin(targetUrl: string): string {
+  try {
+    return new URL(targetUrl).origin;
+  } catch {
+    return "(unparseable target url)";
+  }
+}
+
+/**
  * Strip credentials before a proxy URL reaches a log line — proxy passwords are
  * as sensitive as the API key and logs get pasted into bug reports.
  */
@@ -127,7 +141,7 @@ export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
   try {
     const agents = getAgents(proxyUrl);
     logger.debug("Routing request through proxy", {
-      target: targetUrl,
+      target: targetOrigin(targetUrl),
       proxy: redactProxyUrl(proxyUrl),
     });
     return { proxy: false, httpAgent: agents.http, httpsAgent: agents.https };

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -34,21 +34,149 @@ export interface ProxyAxiosOptions {
   httpsAgent?: Agent;
 }
 
+/** Raised when a proxy is configured but cannot be used as written. */
+export class ProxyConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ProxyConfigurationError";
+  }
+}
+
+const DEFAULT_PROXY_CONNECT_TIMEOUT_MS = 30000;
+
+/**
+ * Deadline for reaching the proxy and completing the `CONNECT` handshake.
+ *
+ * Axios' own `timeout` cannot cover this: it is armed with
+ * `ClientRequest.setTimeout`, which only starts once the request has a socket,
+ * and a proxy agent hands the socket over only after the tunnel is negotiated.
+ * A proxy that accepts the TCP connection and then never answers `CONNECT`
+ * therefore leaves the tool call pending indefinitely — well past the 30s
+ * axios timeout. Overridable for environments where a slow proxy is normal.
+ */
+function connectTimeoutMs(): number {
+  const raw = process.env.COGNIGY_PROXY_CONNECT_TIMEOUT_MS;
+  if (!raw) return DEFAULT_PROXY_CONNECT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.warn(
+      "Ignoring invalid COGNIGY_PROXY_CONNECT_TIMEOUT_MS; using the default",
+      { value: raw, default: DEFAULT_PROXY_CONNECT_TIMEOUT_MS },
+    );
+    return DEFAULT_PROXY_CONNECT_TIMEOUT_MS;
+  }
+  return parsed;
+}
+
+interface ConnectableAgent {
+  connect: (...args: never[]) => Promise<unknown>;
+  /** Options both proxy agents hand to `net.connect`/`tls.connect`. */
+  connectOpts?: Record<string, unknown>;
+}
+
+/**
+ * Wrap an agent's `connect()` so proxy connection plus tunnel negotiation is
+ * bounded. On expiry the request fails with `ETIMEDOUT`; a socket that arrives
+ * late is destroyed rather than left holding a file descriptor for a tunnel
+ * nobody is waiting on any more.
+ */
+function withConnectDeadline<A extends ConnectableAgent>(
+  agent: A,
+  timeoutMs: number,
+  proxyLabel: string,
+): A {
+  const original = agent.connect.bind(agent) as (
+    ...args: never[]
+  ) => Promise<unknown>;
+
+  agent.connect = ((...args: never[]) => {
+    // Abort the socket the agent is about to open, so an expired attempt does
+    // not leave a file descriptor held open against a proxy that never
+    // answers. Both pinned agents build their socket with
+    // `net.connect(this.connectOpts)` synchronously, before their first
+    // `await`, so injecting the signal immediately before the call and
+    // removing it immediately after cannot interleave with another connect —
+    // there is no suspension point in between. Verified against
+    // http(s)-proxy-agent 9.1.0, which the manifest pins exactly.
+    const controller = new AbortController();
+    const connectOpts = agent.connectOpts;
+    const canSignal = Boolean(connectOpts) && !("signal" in connectOpts!);
+    if (canSignal) connectOpts!.signal = controller.signal;
+    let connecting: Promise<unknown>;
+    try {
+      connecting = original(...args);
+    } finally {
+      if (canSignal) delete connectOpts!.signal;
+    }
+
+    let timer: NodeJS.Timeout | undefined;
+    let expired = false;
+
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        expired = true;
+        controller.abort();
+        const error: NodeJS.ErrnoException = new Error(
+          `Timed out after ${timeoutMs}ms connecting through the proxy ${proxyLabel}. ` +
+            `The proxy accepted the connection but did not complete the tunnel. ` +
+            `Check the proxy address, and raise COGNIGY_PROXY_CONNECT_TIMEOUT_MS if it is simply slow.`,
+        );
+        error.code = "ETIMEDOUT";
+        reject(error);
+      }, timeoutMs);
+      // Never keep the process alive for this timer alone; the pending socket
+      // already holds the event loop for as long as the attempt is live.
+      timer.unref?.();
+    });
+
+    connecting.then(
+      (socket) => {
+        if (expired) (socket as { destroy?: () => void })?.destroy?.();
+      },
+      () => {
+        // The underlying failure is already the rejection of `connecting`,
+        // which the race below propagates; swallow it here so a late rejection
+        // after the deadline fired is not an unhandled rejection.
+      },
+    );
+
+    return Promise.race([connecting, deadline]).finally(() =>
+      clearTimeout(timer),
+    );
+  }) as A["connect"];
+
+  return agent;
+}
+
 /**
  * Agents are pooled per proxy URL. Each one owns a socket pool, so building a
  * fresh agent per request would leak sockets and re-do the `CONNECT` handshake
- * every time.
+ * every time. The deadline is part of the key so changing it takes effect
+ * rather than being masked by a cached agent.
  */
 const agentCache = new Map<string, { http: Agent; https: Agent }>();
 
 function getAgents(proxyUrl: string): { http: Agent; https: Agent } {
-  let agents = agentCache.get(proxyUrl);
+  const timeoutMs = connectTimeoutMs();
+  const cacheKey = `${proxyUrl}|${timeoutMs}`;
+  let agents = agentCache.get(cacheKey);
   if (!agents) {
+    const label = redactProxyUrl(proxyUrl);
     agents = {
-      http: new HttpProxyAgent(proxyUrl),
-      https: new HttpsProxyAgent(proxyUrl),
+      http: withConnectDeadline(
+        new HttpProxyAgent(proxyUrl) as unknown as HttpProxyAgent<string> &
+          ConnectableAgent,
+        timeoutMs,
+        label,
+      ) as unknown as Agent,
+      https: withConnectDeadline(
+        new HttpsProxyAgent(proxyUrl) as unknown as HttpsProxyAgent<string> &
+          ConnectableAgent,
+        timeoutMs,
+        label,
+      ) as unknown as Agent,
     };
-    agentCache.set(proxyUrl, agents);
+    agentCache.set(cacheKey, agents);
   }
   return agents;
 }
@@ -108,8 +236,18 @@ function describeUnsupportedProxy(proxyUrl: string): string | undefined {
 /**
  * Resolve the proxy configured for `targetUrl` and return the axios options
  * that route through it. With no proxy configured (or the target excluded by
- * `NO_PROXY`) this still returns `proxy: false`, which is what axios does
- * anyway when no proxy env var is set — so the no-proxy path is unchanged.
+ * `NO_PROXY`) this returns `proxy: false` and no agents, which is what axios
+ * does anyway when no proxy env var is set — so the no-proxy path is unchanged.
+ *
+ * Resolve per request, not per client: `NO_PROXY` and the proxy variables are
+ * matched against the individual target, and requests do not all share a host
+ * (a package download link points at wherever the platform staged the archive).
+ *
+ * Throws `ProxyConfigurationError` when a proxy IS configured for the target
+ * but cannot be used as written. Connecting directly instead would send the API
+ * key and the request body outside the sanctioned proxy path, and on a network
+ * that forbids direct egress it would replace an actionable configuration error
+ * with a puzzling connection failure.
  */
 export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
   let proxyUrl = "";
@@ -127,15 +265,10 @@ export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
 
   const rejection = describeUnsupportedProxy(proxyUrl);
   if (rejection) {
-    // Warn and connect directly rather than tunnelling through something that
-    // cannot work: the agents accept almost any string and would silently
-    // build a tunnel to a nonsense host, turning a typo into a connection
-    // timeout with no clue as to why.
-    logger.warn(
-      `Ignoring proxy configuration (${rejection}); connecting directly instead`,
-      { proxy: redactProxyUrl(proxyUrl) },
+    throw new ProxyConfigurationError(
+      `Cannot use the configured proxy ${redactProxyUrl(proxyUrl)}: ${rejection}. ` +
+        `Fix the proxy setting, or exclude ${targetOrigin(targetUrl)} with NO_PROXY to connect directly.`,
     );
-    return { proxy: false };
   }
 
   try {
@@ -146,14 +279,10 @@ export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
     });
     return { proxy: false, httpAgent: agents.http, httpsAgent: agents.https };
   } catch (error: any) {
-    // An unusable proxy URL must not take the whole server down at construction
-    // time. Warn loudly and fall back to a direct connection, which fails with
-    // a network error the user can act on.
-    logger.warn(
-      "Ignoring unusable proxy configuration; connecting directly instead",
-      { proxy: redactProxyUrl(proxyUrl), error: error?.message },
+    throw new ProxyConfigurationError(
+      `Cannot use the configured proxy ${redactProxyUrl(proxyUrl)}: ${error?.message ?? "unusable proxy configuration"}. ` +
+        `Fix the proxy setting, or exclude ${targetOrigin(targetUrl)} with NO_PROXY to connect directly.`,
     );
-    return { proxy: false };
   }
 }
 
@@ -178,6 +307,16 @@ export function logProxyConfiguration(apiBaseUrl: string): void {
   }
 
   if (proxyUrl) {
+    const rejection = describeUnsupportedProxy(proxyUrl);
+    if (rejection) {
+      // Requests will fail with the same complaint, but say it once at boot so
+      // the problem is visible in the client's log before the first tool call.
+      logger.error("The configured proxy cannot be used", {
+        proxy: redactProxyUrl(proxyUrl),
+        reason: rejection,
+      });
+      return;
+    }
     logger.info("Cognigy API requests route through a proxy", {
       proxy: redactProxyUrl(proxyUrl),
       extraCaCerts: process.env.NODE_EXTRA_CA_CERTS ?? "(not set)",

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -1,0 +1,176 @@
+/**
+ * Corporate-proxy support for every outbound Cognigy request.
+ *
+ * Axios reads `HTTP_PROXY`/`HTTPS_PROXY` itself, but its Node adapter does NOT
+ * open a `CONNECT` tunnel: `setProxy()` rewrites the request to target the
+ * proxy host with an absolute-form path and takes the protocol from the proxy,
+ * so an `https://` Cognigy call leaves the process as a *plaintext* HTTP
+ * request asking the proxy to go fetch an HTTPS URL. Squid, Zscaler, BlueCoat
+ * and friends reject that form and answer with an HTML error page, which the
+ * client then surfaces as a bare `API request failed / 500` — the platform is
+ * never reached. Hence `proxy: false` on every axios instance plus a real
+ * tunnelling agent from here.
+ *
+ * `getProxyForUrl` (axios' own transitive dependency) resolves the proxy for a
+ * given target: it honours upper- and lower-case `HTTP_PROXY`/`HTTPS_PROXY`,
+ * `NO_PROXY` exclusions, `ALL_PROXY`, and `NPM_CONFIG_*` variants, so the
+ * variables users already set for npm and every other CLI keep working.
+ *
+ * TLS-inspecting proxies need one more thing that no library can do for us:
+ * the corporate root CA. Node only reads it from `NODE_EXTRA_CA_CERTS` at
+ * startup, so the user must set that env var next to their proxy vars — we
+ * never disable certificate verification to paper over it.
+ */
+import type { Agent } from "http";
+import { HttpProxyAgent } from "http-proxy-agent";
+import { HttpsProxyAgent } from "https-proxy-agent";
+import { getProxyForUrl } from "proxy-from-env";
+import { logger } from "./logger.js";
+
+export interface ProxyAxiosOptions {
+  /** Always false: axios' own proxy handling is what we are working around. */
+  proxy: false;
+  httpAgent?: Agent;
+  httpsAgent?: Agent;
+}
+
+/**
+ * Agents are pooled per proxy URL. Each one owns a socket pool, so building a
+ * fresh agent per request would leak sockets and re-do the `CONNECT` handshake
+ * every time.
+ */
+const agentCache = new Map<string, { http: Agent; https: Agent }>();
+
+function getAgents(proxyUrl: string): { http: Agent; https: Agent } {
+  let agents = agentCache.get(proxyUrl);
+  if (!agents) {
+    agents = {
+      http: new HttpProxyAgent(proxyUrl),
+      https: new HttpsProxyAgent(proxyUrl),
+    };
+    agentCache.set(proxyUrl, agents);
+  }
+  return agents;
+}
+
+/**
+ * Strip credentials before a proxy URL reaches a log line — proxy passwords are
+ * as sensitive as the API key and logs get pasted into bug reports.
+ */
+export function redactProxyUrl(proxyUrl: string): string {
+  try {
+    const url = new URL(proxyUrl);
+    if (url.username || url.password) {
+      url.username = "***";
+      url.password = "";
+    }
+    return url.toString();
+  } catch {
+    return "(unparseable proxy url)";
+  }
+}
+
+/**
+ * Returns a reason string when `proxyUrl` is something we cannot tunnel
+ * through, or `undefined` when it is usable. SOCKS proxies would need
+ * `socks-proxy-agent`; naming that explicitly beats a mystery timeout.
+ */
+function describeUnsupportedProxy(proxyUrl: string): string | undefined {
+  let parsed: URL;
+  try {
+    parsed = new URL(proxyUrl);
+  } catch {
+    return "not a valid URL — expected something like http://proxy.example:8080";
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return `unsupported proxy protocol "${parsed.protocol}" — only http and https proxies are supported`;
+  }
+  if (!parsed.hostname) {
+    return "no proxy host in the URL";
+  }
+  return undefined;
+}
+
+/**
+ * Resolve the proxy configured for `targetUrl` and return the axios options
+ * that route through it. With no proxy configured (or the target excluded by
+ * `NO_PROXY`) this still returns `proxy: false`, which is what axios does
+ * anyway when no proxy env var is set — so the no-proxy path is unchanged.
+ */
+export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
+  let proxyUrl = "";
+  try {
+    proxyUrl = getProxyForUrl(targetUrl);
+  } catch {
+    // A malformed target URL is the caller's problem, not ours; let the
+    // request itself fail with a useful message instead of throwing here.
+    proxyUrl = "";
+  }
+
+  if (!proxyUrl) {
+    return { proxy: false };
+  }
+
+  const rejection = describeUnsupportedProxy(proxyUrl);
+  if (rejection) {
+    // Warn and connect directly rather than tunnelling through something that
+    // cannot work: the agents accept almost any string and would silently
+    // build a tunnel to a nonsense host, turning a typo into a connection
+    // timeout with no clue as to why.
+    logger.warn(
+      `Ignoring proxy configuration (${rejection}); connecting directly instead`,
+      { proxy: redactProxyUrl(proxyUrl) },
+    );
+    return { proxy: false };
+  }
+
+  try {
+    const agents = getAgents(proxyUrl);
+    logger.debug("Routing request through proxy", {
+      target: targetUrl,
+      proxy: redactProxyUrl(proxyUrl),
+    });
+    return { proxy: false, httpAgent: agents.http, httpsAgent: agents.https };
+  } catch (error: any) {
+    // An unusable proxy URL must not take the whole server down at construction
+    // time. Warn loudly and fall back to a direct connection, which fails with
+    // a network error the user can act on.
+    logger.warn(
+      "Ignoring unusable proxy configuration; connecting directly instead",
+      { proxy: redactProxyUrl(proxyUrl), error: error?.message },
+    );
+    return { proxy: false };
+  }
+}
+
+/** Test seam: proxy env vars are read per call, but agents are cached. */
+export function clearProxyAgentCache(): void {
+  agentCache.clear();
+}
+
+/**
+ * Announce the effective proxy once at boot. Support cases behind a corporate
+ * proxy hinge on whether the server actually picked the variables up — a GUI
+ * client (Claude Desktop, Antigravity) starts the server with a minimal
+ * environment that often lacks the shell's proxy vars entirely — and this line
+ * answers that from the client's own MCP log without asking for a repro.
+ */
+export function logProxyConfiguration(apiBaseUrl: string): void {
+  let proxyUrl = "";
+  try {
+    proxyUrl = getProxyForUrl(apiBaseUrl);
+  } catch {
+    proxyUrl = "";
+  }
+
+  if (proxyUrl) {
+    logger.info("Cognigy API requests route through a proxy", {
+      proxy: redactProxyUrl(proxyUrl),
+      extraCaCerts: process.env.NODE_EXTRA_CA_CERTS ?? "(not set)",
+    });
+  } else {
+    logger.debug("No proxy configured for the Cognigy API", {
+      apiBaseUrl,
+    });
+  }
+}

--- a/src/utils/proxy.ts
+++ b/src/utils/proxy.ts
@@ -260,7 +260,11 @@ export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
   }
 
   if (!proxyUrl) {
-    return { proxy: false };
+    // The agent keys are present-but-undefined on purpose: these options are
+    // `Object.assign`ed onto a request config that may already carry agents
+    // from an earlier resolution (a retry reuses the same config object), and
+    // an absent key would leave the stale agent in place.
+    return { proxy: false, httpAgent: undefined, httpsAgent: undefined };
   }
 
   const rejection = describeUnsupportedProxy(proxyUrl);
@@ -284,6 +288,63 @@ export function getProxyAxiosOptions(targetUrl: string): ProxyAxiosOptions {
         `Fix the proxy setting, or exclude ${targetOrigin(targetUrl)} with NO_PROXY to connect directly.`,
     );
   }
+}
+
+/**
+ * Options follow-redirects hands to `beforeRedirect`, already rewritten to the
+ * redirect destination. Only the fields we read or replace are named.
+ */
+interface RedirectRequestOptions {
+  href?: string;
+  protocol?: string;
+  host?: string;
+  path?: string;
+  agent?: Agent;
+  agents?: { http?: Agent; https?: Agent };
+}
+
+function redirectTargetUrl(options: RedirectRequestOptions): string {
+  if (options.href) return options.href;
+  // `href` is one of the fields follow-redirects copies from the resolved
+  // redirect URL, so this is belt and braces; rebuild it if a future version
+  // stops carrying it rather than silently routing against an empty string.
+  return `${options.protocol ?? "http:"}//${options.host ?? ""}${options.path ?? ""}`;
+}
+
+/**
+ * Re-route a redirect hop through whatever proxy its *destination* needs.
+ *
+ * Redirects are followed inside axios' transport (follow-redirects), which
+ * never re-enters the request interceptor, so the agents chosen for the
+ * original URL would otherwise be reused for every hop. That silently breaks
+ * both directions: a `NO_PROXY` host redirecting to a proxied host stays
+ * direct, and a proxied host redirecting to a `NO_PROXY` host keeps the
+ * tunnel. Axios' own equivalent (`setProxy`'s `beforeRedirects.proxy`) is a
+ * no-op for us because we pass `proxy: false`. Package downloads are the real
+ * case: the API answers with a link that redirects to the archive host.
+ *
+ * follow-redirects re-picks `agent` from `agents[scheme]` on every hop (a
+ * redirect may switch protocol), so the map is the authoritative slot and
+ * `agent` is set only to cover options axios did not build. Assigning
+ * `undefined` is what clears a previously selected proxy agent and sends the
+ * hop direct.
+ *
+ * Throws `ProxyConfigurationError` when the destination needs a proxy we
+ * cannot use — the same refusal as a first-hop request, rather than leaking
+ * the redirected request past the sanctioned proxy path.
+ */
+export function applyProxyToRedirect(
+  redirectOptions: Record<string, unknown>,
+): void {
+  const options = redirectOptions as RedirectRequestOptions;
+  const { httpAgent, httpsAgent } = getProxyAxiosOptions(
+    redirectTargetUrl(options),
+  );
+  if (options.agents) {
+    options.agents.http = httpAgent;
+    options.agents.https = httpsAgent;
+  }
+  options.agent = options.protocol === "https:" ? httpsAgent : httpAgent;
 }
 
 /** Test seam: proxy env vars are read per call, but agents are cached. */


### PR DESCRIPTION
## Summary

- Fixes the reported bug where, behind a corporate proxy, the tool list loads but **every** tool call returns `{"error":"API request failed","status":500}` — and setting `HTTP_PROXY`/`HTTPS_PROXY` changes nothing.
- Root cause is in axios, not the customer's network: axios reads the proxy env vars but its Node adapter never opens a `CONNECT` tunnel, so an `https://` Cognigy call leaves the process as a plaintext HTTP request asking the proxy to fetch an HTTPS URL. Corporate proxies reject that form and answer with an HTML error page — the platform is never reached.
- Adds real tunnelling agents (`proxy: false` + `http(s)-proxy-agent`) for every outbound request, and makes the error message name what actually responded instead of collapsing to a generic string.

## Root cause

`node_modules/axios/lib/adapters/http.js` → `setProxy()`:

```js
options.hostname = proxyHost;   // send to the proxy
options.path = location;        // absolute-form URI
options.protocol = proxy.protocol; // http: — so no client-side TLS at all
```

The request the proxy expects is `CONNECT api-*.cognigy.ai:443`, followed by an end-to-end TLS handshake through the resulting tunnel. What it received instead was `GET https://api-*.cognigy.ai/v2.0/... HTTP/1.1` in cleartext. Squid, Zscaler, BlueCoat and similar refuse that and return a 5xx HTML page.

`formatError` then looked for Cognigy's `detail`/`title` fields, found neither, and fell back to `"API request failed"` — which is why the report carried no clue that a proxy was involved.

The tool list works because `ListTools` makes no HTTP request, which is the tell for this class of failure.

## Changes

| File / Component | Description |
| ---------------- | ----------- |
| `src/utils/proxy.ts` | New. Resolves the proxy for a target URL via `proxy-from-env` (axios' own dependency, so upper/lower-case vars, `ALL_PROXY` and `NO_PROXY` behave as users already expect) and returns axios options with `proxy: false` plus pooled `HttpProxyAgent`/`HttpsProxyAgent`. Rejects unusable values (no host, SOCKS) with a warning and a direct connection rather than tunnelling to a nonsense host. Redacts credentials before logging. |
| `src/api/client.ts` | Applies those options to the axios instance, so every platform request — uploads included — is tunnelled. `describeUnexpectedBody` replaces the bare `"API request failed"` with the HTTP status, a whitespace-collapsed 300-char snippet of the body, and, when a proxy applies to that request, the redacted proxy URL plus the `NODE_EXTRA_CA_CERTS` hint. |
| `src/tools/handlers.ts` | `talk_to_agent`'s standalone `axios.post` gets the same wiring, resolved per call — the endpoint host differs from the API host and may be excluded by `NO_PROXY` independently. |
| `src/index.ts`, `src/utils/proxy.ts` | Logs the effective proxy once at boot, so support can tell from the client's MCP log whether the engine picked the settings up. GUI clients (Desktop, Antigravity) start the engine with a minimal environment and often do not inherit shell proxy variables. |
| `src/types/proxy-from-env.d.ts` | Four-line declaration for the one untyped function used, instead of a dev dependency. |
| `package.json` | Adds `https-proxy-agent`, `http-proxy-agent` (pinned `9.1.0`) and `proxy-from-env` (`1.1.0`, already in the tree via axios). |
| `README.md`, `plugin/skills/troubleshooting/SKILL.md`, `.claude/CLAUDE.md` | Documents the env vars, the TLS-inspection case, and the "tool list works but every call fails" symptom. |

## Test plan

Automated:

- `npm test` — 659 passed, 3 skipped. 23 new tests across `src/__tests__/proxy.test.ts` (agents attached, `proxy: false` always, lower-case vars, `NO_PROXY` honoured, credentials passed through, agents pooled, SOCKS and hostless URLs refused, credentials redacted) and `src/__tests__/apiErrorMessages.test.ts` (status + snippet, HTML/JSON/Buffer bodies, truncation, proxy named only when one applies, no throw on a config with no usable URL).
- `npx tsc -p tsconfig.json --noEmit`
- `npm run build`
- `npm run check:manifest`

Manual — end-to-end against a local proxy that accepts **only** `CONNECT` and answers absolute-form requests with a 501 HTML page, fronting an HTTPS target with a self-signed cert trusted via `NODE_EXTRA_CA_CERTS`:

```
OLD: status=501 body=<html><head><title>ERROR</title></head><body> <p>ERROR: The requested URL could…
NEW: {"items":[{"name":"tunnelled ok","url":"/v2.0/projects"}]}

proxy: refused absolute-form request -> https://localhost:8443/v2.0/projects
proxy: CONNECT -> localhost:8443
```

The first two lines are the same env vars through the old and new code paths; the proxy log shows the request shape changing from rejected absolute-form to an accepted tunnel. This also exercises the `NODE_EXTRA_CA_CERTS` path, since the tunnelled TLS handshake verifies against that CA.

## Breaking changes / migration

- None. With no proxy configured the options are `{ proxy: false }` and no agents, which matches what axios does anyway when no proxy variable is set — the direct-connection path is unchanged.

## Support answer for the reported issue

Running behind a corporate proxy was **not** supported and the failure is a bug on our side, not customer configuration. After this ships, customers set the proxy in the MCP server `env` block:

```json
"env": {
  "HTTPS_PROXY": "http://proxy.corp.example:8080",
  "NODE_EXTRA_CA_CERTS": "/etc/ssl/certs/corporate-root-ca.pem"
}
```

`NODE_EXTRA_CA_CERTS` is only needed when the proxy inspects TLS, and requires a client restart because Node reads it at startup. Certificate verification is never disabled. HTTP and HTTPS proxies are supported; SOCKS proxies are not, and are now refused with an explicit message rather than failing obscurely.

## Marketplace checklist

- [x] Versions left untouched — `package.json` and `plugin/.claude-plugin/plugin.json` are synced automatically by semantic-release on merge (`scripts/sync-plugin-version.mjs`); do not hand-edit either `version`
- [x] Tool count in `README.md` updated if the tool surface changed — unchanged, still 17 tools
- [x] `README.md` updated if user-facing behavior changed — new "Corporate proxies" section and three env-var rows
- [x] Tool annotations/descriptions reviewed if tool behavior changed — no tool contract changed
- [x] `LICENSE` / marketplace metadata reviewed if submission requirements are affected — unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
